### PR TITLE
Fix overwrite same file.

### DIFF
--- a/storage/index.html
+++ b/storage/index.html
@@ -85,7 +85,7 @@ limitations under the License.
       };
 
       // Push to child path.
-      var uploadTask = storageRef.child('images').put(file, metadata);
+      var uploadTask = storageRef.child('images/' + file.name).put(file, metadata);
 
       // Listen for errors and completion of the upload.
       // [START oncomplete]


### PR DESCRIPTION
Currently each upload overwrite the same file called `images`.
I think this behavior is not expected.

Each file will be upload to the folder `images` and is called like the `file.name` from the hdd.

This PR fix https://github.com/firebase/quickstart-js/issues/6 too