### PR TITLE
Remove the defer attribute

### DIFF
--- a/database/index.html
+++ b/database/index.html
@@ -40,7 +40,7 @@
   <!-- Material Design Lite -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="https://code.getmdl.io/1.1.3/material.blue_grey-orange.min.css">
-  <script defer src="https://code.getmdl.io/1.1.3/material.min.js"></script>
+  <script src="https://code.getmdl.io/1.1.3/material.min.js"></script>
 
   <link rel="stylesheet" href="main.css">
 


### PR DESCRIPTION
Remove the defer attribute from Material Design Lite library script element so It can work fine.
Please refer to the following issue.

[https://github.com/firebase/quickstart-js/issues/46](https://github.com/firebase/quickstart-js/issues/46)