### PR TITLE
Bump firebase version in messaging SW

### DIFF
--- a/messaging/firebase-messaging-sw.js
+++ b/messaging/firebase-messaging-sw.js
@@ -2,8 +2,8 @@
 // Give the service worker access to Firebase Messaging.
 // Note that you can only use Firebase Messaging here, other Firebase libraries
 // are not available in the service worker.
-importScripts('https://www.gstatic.com/firebasejs/3.5.0/firebase-app.js');
-importScripts('https://www.gstatic.com/firebasejs/3.5.0/firebase-messaging.js');
+importScripts('https://www.gstatic.com/firebasejs/3.5.2/firebase-app.js');
+importScripts('https://www.gstatic.com/firebasejs/3.5.2/firebase-messaging.js');
 
 // Initialize the Firebase app in the service worker by passing in the
 // messagingSenderId.


### PR DESCRIPTION
This should fix #70 

This was a bug I caught too late on to get in the 3.5.0 release but was fixed in 3.5.1 and above.

Should this sample code have the firebase version just marked as X.X.X with a todo comment? or is using a static version ok?

cc @kroikie 