### PR TITLE
Correct meta tag

### DIFF
--- a/auth/index.html
+++ b/auth/index.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 <html>
 <head>
-  <meta charset=utf-8/>
+  <meta charset=utf-8 />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Firebase Authentication Example</title>
 

--- a/messaging/index.html
+++ b/messaging/index.html
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 <html>
 <head>
-  <meta charset=utf-8/>
+  <meta charset=utf-8 />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Firebase Cloud Messaging Example</title>
 


### PR DESCRIPTION
Several `index.html` files fail HTML5 validation. I'd be inclined to remove the `/` in the `meta` tags altogether but, being unsure about the conformance requirements for this codebase, adding a space seemed the least intrusive approach.