### PR TITLE
Fix image links to be relative

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -15,12 +15,12 @@ Getting Started
 
 - Create your project on the [Firebase Console](https://console.firebase.google.com).
 - From your Firebase project console, click on red circle button with the caption "Add Firebase to your web app".
-![Alt text](/database/pics/redcircle.png?raw=true "Red Circle")
+![Alt text](pics/redcircle.png?raw=true "Red Circle")
 - Copy the initialization snippet into the index.html file by clicking the red HTML.
-![Alt text](/database/pics/snippet.png?raw=true "Snippet")
+![Alt text](pics/snippet.png?raw=true "Snippet")
 - The snippet should be placed in the `<head>` section of `index.html`.
 - Enable Google auth in the **Auth > SIGN IN METHOD** tab.
-![Alt text](/database/pics/enable.png?raw=true "Enable google auth")
+![Alt text](pics/enable.png?raw=true "Enable google auth")
 - Run `firebase serve` using the Firebase CLI tool to launch a local server.
 
 Support

--- a/storage/README.md
+++ b/storage/README.md
@@ -13,9 +13,9 @@ Getting Started
 
 - Create your project on the [Firebase Console](https://console.firebase.google.com).
 - From your Firebase project console, click on red circle button with the caption "Add Firebase to your web app".
-![Alt text](/storage/pics/redcircle.png?raw=true "Red Circle")
+![Alt text](pics/redcircle.png?raw=true "Red Circle")
 - Copy the initialization snippet into the index.html file by clicking the red HTML.
-![Alt text](/storage/pics/snippet.png?raw=true "Snippet")
+![Alt text](pics/snippet.png?raw=true "Snippet")
 - The snippet which appears should be placed in the `<head>` section of `index.html`.
 - Enable Anonymous auth in the **Auth > SIGN IN METHOD** tab.
 ![Alt text](/storage/pics/enable.png?raw=true "Enable auth")


### PR DESCRIPTION
Image links in README.md are broken when viewed with a local markdown editor. Changing them to relative links fixes the problem and they still work fine on GitHub.