### PR TITLE
Use Implicit Firebase initialization in the FCM sample.

### DIFF
--- a/messaging/README.md
+++ b/messaging/README.md
@@ -14,7 +14,6 @@ Getting Started
 ---------------
 
 1. Create your project on the [Firebase Console](https://console.firebase.google.com).
-1. Enable the **Google** sign-in provider in the **Authentication > SIGN-IN METHOD** tab.
 1. You must have the Firebase CLI installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.
 1. On the command line run `firebase use --add` and select the Firebase project you have created.
 1. On the command line run `firebase serve -p 8081` using the Firebase CLI tool to launch a local server.

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -14,7 +14,7 @@ Getting Started
 ---------------
 
 1. Create your project on the [Firebase Console](https://console.firebase.google.com).
-1. You must have the Firebase CLI installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.
+1. You must have the [Firebase CLI](https://firebase.google.com/docs/cli/) installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.
 1. On the command line run `firebase use --add` and select the Firebase project you have created.
 1. On the command line run `firebase serve -p 8081` using the Firebase CLI tool to launch a local server.
 1. Open [http://localhost:8081](http://localhost:8081) in your browser.

--- a/messaging/README.md
+++ b/messaging/README.md
@@ -8,25 +8,19 @@ The Firebase Cloud Messaging quickstart demonstrates how to:
 Introduction
 ------------
 
-- [Read more about Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/)
+[Read more about Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/)
 
 Getting Started
 ---------------
 
-1. Set up your project on the [Firebase Console](https://console.firebase.google.com).
-2. Paste initialization snippet into `index.html` with the one generated from
-   the Firebase Console **Overview > Add Firebase to your web app**. See TODO in
-   `index.html`.
-3. Run the app
-     - Install the [Firebase CLI](https://firebase.google.com/docs/cli/)
-     - Use command `firebase serve -p 8081` to serve app locally.
-     - Open http://localhost:8081 in your browser.
-4. Click REQUEST PERMISSION button to request permission for the app to send
-   notifications to the browser.
-5. Use the generated Instance ID token to send an HTTP request to FCM that
-   delivers the message to the web application, inserting appropriate values
-   for [YOUR-SERVER-KEY](https://console.firebase.google.com/project/_/settings/cloudmessaging)
-   and YOUR-IID-TOKEN.
+1. Create your project on the [Firebase Console](https://console.firebase.google.com).
+1. Enable the **Google** sign-in provider in the **Authentication > SIGN-IN METHOD** tab.
+1. You must have the Firebase CLI installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.
+1. On the command line run `firebase use --add` and select the Firebase project you have created.
+1. On the command line run `firebase serve -p 8081` using the Firebase CLI tool to launch a local server.
+1. Open [http://localhost:8081](http://localhost:8081) in your browser.
+4. Click **REQUEST PERMISSION** button to request permission for the app to send notifications to the browser.
+5. Use the generated Instance ID token (IID Token) to send an HTTP request to FCM that delivers the message to the web application, inserting appropriate values for [`YOUR-SERVER-KEY`](https://console.firebase.google.com/project/_/settings/cloudmessaging) and `YOUR-IID-TOKEN`.
 
 ### HTTP
 ```

--- a/messaging/firebase-messaging-sw.js
+++ b/messaging/firebase-messaging-sw.js
@@ -1,20 +1,35 @@
-// [START initialize_firebase_in_sw]
-// Give the service worker access to Firebase Messaging.
-// Note that you can only use Firebase Messaging here, other Firebase libraries
-// are not available in the service worker.
-importScripts('https://www.gstatic.com/firebasejs/3.5.2/firebase-app.js');
-importScripts('https://www.gstatic.com/firebasejs/3.5.2/firebase-messaging.js');
+// Import and configure the Firebase SDK
+// These scripts are made available when the app is served or deployed on Firebase Hosting
+// If you do not serve/host your project using Firebase Hosting see https://firebase.google.com/docs/web/setup
+importScripts('/__/firebase/3.9.0/firebase-app.js');
+importScripts('/__/firebase/3.9.0/firebase-messaging.js');
+importScripts('/__/firebase/init.js');
 
-// Initialize the Firebase app in the service worker by passing in the
-// messagingSenderId.
-firebase.initializeApp({
-  'messagingSenderId': 'YOUR-SENDER-ID'
-});
-
-// Retrieve an instance of Firebase Messaging so that it can handle background
-// messages.
 const messaging = firebase.messaging();
-// [END initialize_firebase_in_sw]
+
+/**
+ * Here is is the code snippet to initialize Firebase Messaging in the Service
+ * Worker when your app is not hosted on Firebase Hosting.
+
+ // [START initialize_firebase_in_sw]
+ // Give the service worker access to Firebase Messaging.
+ // Note that you can only use Firebase Messaging here, other Firebase libraries
+ // are not available in the service worker.
+ importScripts('https://www.gstatic.com/firebasejs/3.9.0/firebase-app.js');
+ importScripts('https://www.gstatic.com/firebasejs/3.9.0/firebase-messaging.js');
+
+ // Initialize the Firebase app in the service worker by passing in the
+ // messagingSenderId.
+ firebase.initializeApp({
+   'messagingSenderId': 'YOUR-SENDER-ID'
+ });
+
+ // Retrieve an instance of Firebase Messaging so that it can handle background
+ // messages.
+ const messaging = firebase.messaging();
+ // [END initialize_firebase_in_sw]
+ **/
+
 
 // If you would like to customize notifications that are received in the
 // background (Web app is closed or not in browser focus) then you should

--- a/messaging/firebase.json
+++ b/messaging/firebase.json
@@ -1,0 +1,8 @@
+{
+  "hosting": {
+    "public": "./",
+    "ignore": [
+      "firebase.json"
+    ]
+  }
+}

--- a/messaging/index.html
+++ b/messaging/index.html
@@ -175,10 +175,7 @@ limitations under the License.
   }
 
   function isTokenSentToServer() {
-    if (window.localStorage.getItem('sentToServer') == 1) {
-      return true;
-    }
-    return false;
+    return window.localStorage.getItem('sentToServer') == 1;
   }
 
   function setTokenSentToServer(sent) {

--- a/messaging/index.html
+++ b/messaging/index.html
@@ -71,18 +71,14 @@ limitations under the License.
     </div>
   </main>
 </div>
-<!-- Firebase -->
-<!-- ********************************************************
-     * TODO(DEVELOPER): Update Firebase initialization code:
-        1. Go to the Firebase console: https://console.firebase.google.com/
-        2. Choose a Firebase project you've created
-        3. Click "Add Firebase to your web app"
-        4. Replace the following initialization code with the code from the Firebase console:
--->
-<!-- START INITIALIZATION CODE -->
-<!-- PASTE FIREBASE INITIALIZATION CODE HERE -->
-<!-- END INITIALIZATION CODE -->
-<!-- ******************************************************** -->
+
+<!-- Import and configure the Firebase SDK -->
+<!-- These scripts are made available when the app is served or deployed on Firebase Hosting -->
+<!-- If you do not serve/host your project using Firebase Hosting see https://firebase.google.com/docs/web/setup -->
+<script src="/__/firebase/3.9.0/firebase-app.js"></script>
+<script src="/__/firebase/3.9.0/firebase-messaging.js"></script>
+<script src="/__/firebase/init.js"></script>
+
 <script>
   // [START get_messaging_object]
   // Retrieve Firebase Messaging object.
@@ -180,7 +176,7 @@ limitations under the License.
 
   function isTokenSentToServer() {
     if (window.localStorage.getItem('sentToServer') == 1) {
-          return true;
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
This basically allows to run the sample simply with `firebase serve --project <projectid>` without having to configure the sample with project specific values both in the index.html and s=the service workers file.

The change is a bit tricky though because you were using the Firebase initialization in the service workers script as an include in the docs and we should probably still show the non-implicit way of configuring the SDK in the docs so I've worked around it by moving the non-implicit include within a comment.