### PR TITLE
add: Enable Cloud Firestore step

### DIFF
--- a/firestore/README.md
+++ b/firestore/README.md
@@ -13,6 +13,7 @@ Follow these steps to setup and run the quickstart:
 
  1. Create a Firebase project in the [Firebase Console](https://console.firebase.google.com).
  1. In the Firebase console, enable Anonymous authentication on your project by doing: **Authentication > SIGN-IN METHOD > Anonymous > Enable > SAVE**
+ 1. In the Firebase console, enable Cloud Firestore on your project by doing: **Database > TRY FIRESTORE BETA > ENABLE**
  1. Copy/Download this repo and open this folder in a Terminal.
  1. Install the Firebase CLI if you do not have it installed on your machine:
     ```bash
@@ -21,9 +22,7 @@ Follow these steps to setup and run the quickstart:
  1. Set the CLI to use the project you created on step 1:
     ```bash
     firebase use --add
-    ```
- 1. In the Firebase console, enable Cloud Firestore on your project by doing: **Database > TRY FIRESTORE BETA > ENABLE**
- 
+    ``` 
  1. Deploy the Firestore security rules:
     ```bash
     firebase deploy --only firestore

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -22,6 +22,8 @@ Follow these steps to setup and run the quickstart:
     ```bash
     firebase use --add
     ```
+ 1. In the Firebase console, enable Cloud Firestore on your project by doing: **Database > TRY FIRESTORE BETA > ENABLE**
+ 
  1. Deploy the Firestore security rules:
     ```bash
     firebase deploy --only firestore

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -22,7 +22,7 @@ Follow these steps to setup and run the quickstart:
  1. Set the CLI to use the project you created on step 1:
     ```bash
     firebase use --add
-    ``` 
+    ```
  1. Deploy the Firestore security rules:
     ```bash
     firebase deploy --only firestore


### PR DESCRIPTION
I encountered an error upon deploying Firestore security rules before enabling the Cloud Firestore on my Firebase project.

```
Error: HTTP Error: 400, Project 'quickstart-js-firestore' is not a Firestore enabled project.
```

I think this additional step will help others avoid what I experienced.