### PR TITLE
Fixed firestore sample bug

### DIFF
--- a/firestore/scripts/FriendlyEats.Mock.js
+++ b/firestore/scripts/FriendlyEats.Mock.js
@@ -39,7 +39,7 @@ FriendlyEats.prototype.addMockRestaurants = function() {
       category: category,
       price: price,
       city: city,
-      numRating: numRatings,
+      numRatings: numRatings,
       avgRating: avgRating,
       photo: photo
     });


### PR DESCRIPTION
Changed field name from `numRating` to `numRatings` when adding Mock Restaurants. This fixes bug, when after adding a new rating, app takes field `numRatings`, which does not exist, to calculations. The result was *NaN* value in some firestore fields, so average rating was never calculated.