### PR TITLE
Add missing part in documentation for messaging

### DIFF
--- a/messaging/README.md
+++ b/messaging/README.md
@@ -14,12 +14,14 @@ Getting Started
 ---------------
 
 1. Create your project on the [Firebase Console](https://console.firebase.google.com).
+1. Open Project and go to **Project settings > Cloud Messaging** and there in section **Web configuration** click **Generate key pair** button.
+1. Copy public key and in `index.html` file replace `<YOUR_PUBLIC_VAPID_KEY_HERE>` with your key.
 1. You must have the [Firebase CLI](https://firebase.google.com/docs/cli/) installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.
 1. On the command line run `firebase use --add` and select the Firebase project you have created.
 1. On the command line run `firebase serve -p 8081` using the Firebase CLI tool to launch a local server.
 1. Open [http://localhost:8081](http://localhost:8081) in your browser.
-4. Click **REQUEST PERMISSION** button to request permission for the app to send notifications to the browser.
-5. Use the generated Instance ID token (IID Token) to send an HTTP request to FCM that delivers the message to the web application, inserting appropriate values for [`YOUR-SERVER-KEY`](https://console.firebase.google.com/project/_/settings/cloudmessaging) and `YOUR-IID-TOKEN`.
+1. Click **REQUEST PERMISSION** button to request permission for the app to send notifications to the browser.
+1. Use the generated Instance ID token (IID Token) to send an HTTP request to FCM that delivers the message to the web application, inserting appropriate values for [`YOUR-SERVER-KEY`](https://console.firebase.google.com/project/_/settings/cloudmessaging) and `YOUR-IID-TOKEN`.
 
 ### HTTP
 ```


### PR DESCRIPTION
The part about replacing **VAPID KEY** was not described in the documentation which causes problems with quick start with testing firebase cloud messaging. I find many issues and problems on the web. 
I had the same problem too so I add steps in instruction in **README**.
