### PR TITLE
Clarify samples used in the FCM docs

### DIFF
--- a/messaging/index.html
+++ b/messaging/index.html
@@ -98,10 +98,13 @@ limitations under the License.
   messaging.onTokenRefresh(function() {
     messaging.getToken().then(function(refreshedToken) {
       console.log('Token refreshed.');
+      // [START_EXCLUDE]
       // Indicate that the new Instance ID token has not yet been sent to the
       // app server.
       setTokenSentToServer(false);
-      // Send Instance ID token to app server.
+      // [END_EXCLUDE]
+      // Send Instance ID token to your app server.
+      // TODO(developer): implement sendTokenToServer
       sendTokenToServer(refreshedToken);
       // [START_EXCLUDE]
       // Display new Instance ID token and clear UI of all previous messages.
@@ -109,7 +112,9 @@ limitations under the License.
       // [END_EXCLUDE]
     }).catch(function(err) {
       console.log('Unable to retrieve refreshed token ', err);
+      // [START_EXCLUDE]
       showToken('Unable to retrieve refreshed token ', err);
+      // [END_EXCLUDE]
     });
   });
   // [END refresh_token]
@@ -136,14 +141,19 @@ limitations under the License.
     // subsequent calls to getToken will return from cache.
     messaging.getToken().then(function(currentToken) {
       if (currentToken) {
+        // TODO(developer): implement sendTokenToServer
         sendTokenToServer(currentToken);
+        // [START_EXCLUDE]
         updateUIForPushEnabled(currentToken);
+        // [END_EXCLUDE]
       } else {
         // Show permission request.
         console.log('No Instance ID token available. Request permission to generate one.');
+        // [START_EXCLUDE]
         // Show permission UI.
         updateUIForPushPermissionRequired();
         setTokenSentToServer(false);
+        // [END_EXCLUDE]
       }
     }).catch(function(err) {
       console.log('An error occurred while retrieving token. ', err);
@@ -215,8 +225,8 @@ limitations under the License.
     messaging.getToken().then(function(currentToken) {
       messaging.deleteToken(currentToken).then(function() {
         console.log('Token deleted.');
-        setTokenSentToServer(false);
         // [START_EXCLUDE]
+        setTokenSentToServer(false);
         // Once token is deleted update UI.
         resetUI();
         // [END_EXCLUDE]
@@ -226,7 +236,9 @@ limitations under the License.
       // [END delete_token]
     }).catch(function(err) {
       console.log('Error retrieving Instance ID token. ', err);
+      // [START_EXCLUDE]
       showToken('Error retrieving Instance ID token. ', err);
+      // [END_EXCLUDE]
     });
 
   }


### PR DESCRIPTION
added comments and excluded more lines

The samples in [this section](https://firebase.google.com/docs/cloud-messaging/js/client#retrieve-the-current-registration-token) include extra lines of code that aren't necessary to get a barebones sample running. It's also confusing to new developers (per #275) whether the functions in there are part of the Firebase SDK or functions that need to be implemented. 