### PR TITLE
Update firestore settings

### DIFF
--- a/firestore/scripts/FriendlyEats.js
+++ b/firestore/scripts/FriendlyEats.js
@@ -30,10 +30,6 @@ function FriendlyEats() {
 
   var that = this;
 
-  firebase.firestore().settings({
-    timestampsInSnapshots: true
-  });
-
   firebase.firestore().enablePersistence()
     .then(function() {
       return firebase.auth().signInAnonymously();

--- a/messaging/index.html
+++ b/messaging/index.html
@@ -98,13 +98,10 @@ limitations under the License.
   messaging.onTokenRefresh(function() {
     messaging.getToken().then(function(refreshedToken) {
       console.log('Token refreshed.');
-      // [START_EXCLUDE]
       // Indicate that the new Instance ID token has not yet been sent to the
       // app server.
       setTokenSentToServer(false);
-      // [END_EXCLUDE]
-      // Send Instance ID token to your app server.
-      // TODO(developer): implement sendTokenToServer
+      // Send Instance ID token to app server.
       sendTokenToServer(refreshedToken);
       // [START_EXCLUDE]
       // Display new Instance ID token and clear UI of all previous messages.
@@ -112,9 +109,7 @@ limitations under the License.
       // [END_EXCLUDE]
     }).catch(function(err) {
       console.log('Unable to retrieve refreshed token ', err);
-      // [START_EXCLUDE]
       showToken('Unable to retrieve refreshed token ', err);
-      // [END_EXCLUDE]
     });
   });
   // [END refresh_token]
@@ -141,19 +136,14 @@ limitations under the License.
     // subsequent calls to getToken will return from cache.
     messaging.getToken().then(function(currentToken) {
       if (currentToken) {
-        // TODO(developer): implement sendTokenToServer
         sendTokenToServer(currentToken);
-        // [START_EXCLUDE]
         updateUIForPushEnabled(currentToken);
-        // [END_EXCLUDE]
       } else {
         // Show permission request.
         console.log('No Instance ID token available. Request permission to generate one.');
-        // [START_EXCLUDE]
         // Show permission UI.
         updateUIForPushPermissionRequired();
         setTokenSentToServer(false);
-        // [END_EXCLUDE]
       }
     }).catch(function(err) {
       console.log('An error occurred while retrieving token. ', err);
@@ -225,8 +215,8 @@ limitations under the License.
     messaging.getToken().then(function(currentToken) {
       messaging.deleteToken(currentToken).then(function() {
         console.log('Token deleted.');
-        // [START_EXCLUDE]
         setTokenSentToServer(false);
+        // [START_EXCLUDE]
         // Once token is deleted update UI.
         resetUI();
         // [END_EXCLUDE]
@@ -236,9 +226,7 @@ limitations under the License.
       // [END delete_token]
     }).catch(function(err) {
       console.log('Error retrieving Instance ID token. ', err);
-      // [START_EXCLUDE]
       showToken('Error retrieving Instance ID token. ', err);
-      // [END_EXCLUDE]
     });
 
   }

--- a/messaging/index.html
+++ b/messaging/index.html
@@ -98,10 +98,13 @@ limitations under the License.
   messaging.onTokenRefresh(function() {
     messaging.getToken().then(function(refreshedToken) {
       console.log('Token refreshed.');
+      // [START_EXCLUDE]
       // Indicate that the new Instance ID token has not yet been sent to the
       // app server.
       setTokenSentToServer(false);
-      // Send Instance ID token to app server.
+      // [END_EXCLUDE]
+      // Send Instance ID token to your app server.
+      // TODO(developer): implement sendTokenToServer
       sendTokenToServer(refreshedToken);
       // [START_EXCLUDE]
       // Display new Instance ID token and clear UI of all previous messages.
@@ -109,7 +112,9 @@ limitations under the License.
       // [END_EXCLUDE]
     }).catch(function(err) {
       console.log('Unable to retrieve refreshed token ', err);
+      // [START_EXCLUDE]
       showToken('Unable to retrieve refreshed token ', err);
+      // [END_EXCLUDE]
     });
   });
   // [END refresh_token]
@@ -136,14 +141,19 @@ limitations under the License.
     // subsequent calls to getToken will return from cache.
     messaging.getToken().then(function(currentToken) {
       if (currentToken) {
+        // TODO(developer): implement sendTokenToServer
         sendTokenToServer(currentToken);
+        // [START_EXCLUDE]
         updateUIForPushEnabled(currentToken);
+        // [END_EXCLUDE]
       } else {
         // Show permission request.
         console.log('No Instance ID token available. Request permission to generate one.');
+        // [START_EXCLUDE]
         // Show permission UI.
         updateUIForPushPermissionRequired();
         setTokenSentToServer(false);
+        // [END_EXCLUDE]
       }
     }).catch(function(err) {
       console.log('An error occurred while retrieving token. ', err);
@@ -215,8 +225,8 @@ limitations under the License.
     messaging.getToken().then(function(currentToken) {
       messaging.deleteToken(currentToken).then(function() {
         console.log('Token deleted.');
-        setTokenSentToServer(false);
         // [START_EXCLUDE]
+        setTokenSentToServer(false);
         // Once token is deleted update UI.
         resetUI();
         // [END_EXCLUDE]
@@ -226,7 +236,9 @@ limitations under the License.
       // [END delete_token]
     }).catch(function(err) {
       console.log('Error retrieving Instance ID token. ', err);
+      // [START_EXCLUDE]
       showToken('Error retrieving Instance ID token. ', err);
+      // [END_EXCLUDE]
     });
 
   }


### PR DESCRIPTION
Including `timestampsInSnapshots` now causes this warning to show up in the console:

> @firebase/firestore: Firestore (5.9.2): 
  The timestampsInSnapshots setting now defaults to true and you no
  longer need to explicitly set it. In a future release, the setting
  will be removed entirely and so it is recommended that you remove it
  from your firestore.settings() call now.