### PR TITLE
replaced APIs that to be deprecated with the new ones

### DIFF
--- a/auth/chromextension/README.md
+++ b/auth/chromextension/README.md
@@ -78,11 +78,11 @@ The keys to using Firebase in a Chrome extension are:
    - Create a new OAuth Client ID in your project's [Developers Console](https://console.developers.google.com/apis/credentials/oauthclient?project=_), Select **Chrome App** and enter your Chrome Extension/App ID.
    - In your project's Firebase Console, enable the **Google** authentication method in the **Auth** section > **SIGN IN METHOD** tab.
    - Add the Client ID you created to the whitelist using the **Whitelist client IDs from external projects (optional)**
- - Use the chrome.identity API to get a Google OAuth token as described in https://developer.chrome.com/apps/app_identity and then use this token to authorize Firebase using [Auth.signInAndRetrieveDataWithCredential()](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signInAndRetrieveDataWithCredential):
+ - Use the chrome.identity API to get a Google OAuth token as described in https://developer.chrome.com/apps/app_identity and then use this token to authorize Firebase using [Auth.signInWithCredential()](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signInWithCredential):
 
  ```javascript
  var credential = firebase.auth.GoogleAuthProvider.credential(null, token);
- firebase.auth().signInAndRetrieveDataWithCredential(credential);
+ firebase.auth().signInWithCredential(credential);
  ```
 
  - Add the following content security policy to your `manifest.json` to allow importing the Firebase SDK and accessing the Realtime Database as well as Firebase Storage:

--- a/auth/chromextension/credentials.js
+++ b/auth/chromextension/credentials.js
@@ -68,7 +68,7 @@ function startAuth(interactive) {
     } else if (token) {
       // Authorize Firebase with the OAuth Access Token.
       var credential = firebase.auth.GoogleAuthProvider.credential(null, token);
-      firebase.auth().signInAndRetrieveDataWithCredential(credential).catch(function(error) {
+      firebase.auth().signInWithCredential(credential).catch(function(error) {
         // The OAuth token might have been invalidated. Lets' remove it from cache.
         if (error.code === 'auth/invalid-credential') {
           chrome.identity.removeCachedAuthToken({token: token}, function() {

--- a/auth/facebook-credentials.html
+++ b/auth/facebook-credentials.html
@@ -92,7 +92,7 @@ limitations under the License.
             // [END facebookcredential]
             // Sign in with the credential from the Facebook user.
             // [START authwithcred]
-            firebase.auth().signInAndRetrieveDataWithCredential(credential).catch(function(error) {
+            firebase.auth().signInWithCredential(credential).catch(function(error) {
               // Handle Errors here.
               var errorCode = error.code;
               var errorMessage = error.message;

--- a/auth/google-credentials.html
+++ b/auth/google-credentials.html
@@ -72,7 +72,7 @@ limitations under the License.
           // [END googlecredential]
           // Sign in with credential from the Google user.
           // [START authwithcred]
-          firebase.auth().signInAndRetrieveDataWithCredential(credential).catch(function(error) {
+          firebase.auth().signInWithCredential(credential).catch(function(error) {
             // Handle Errors here.
             var errorCode = error.code;
             var errorMessage = error.message;


### PR DESCRIPTION
In Firebase V6, signInAndRetrieveDataWithCredential will be deprecated in favor of signInWithCredential. Replace them in the sample apps.