### PR TITLE
Fix engines missing in functions/functions

### DIFF
--- a/functions/functions/package.json
+++ b/functions/functions/package.json
@@ -19,5 +19,8 @@
     "eslint": "^4.12.0",
     "eslint-plugin-promise": "^3.6.0"
   },
+  "engines": {
+    "node": "8"
+  },
   "private": true
 }


### PR DESCRIPTION
When I run `firebase deploy` following the instruction in README.md, I got an error like this:

```
functions git:master ✶ ✩  ❯ firebase deploy

=== Deploying to 'quickstart-js-XXXXX'...

i  deploying database, functions, hosting
Running command: npm --prefix "$RESOURCE_DIR" run lint

> functions@ lint /Users/amagi/src/github.com/firebase/quickstart-js/functions/functions
> eslint .

✔  functions: Finished running predeploy script.
i  database: checking rules syntax...
✔  database: rules syntax for database quickstart-js-XXXXX is valid

Error: There was an error reading functions/package.json:

 Engines field is required but was not found in functions/package.json.
To fix this, add the following lines to your package.json:

      "engines": {
        "node": "8"
      }

 ⌚︎ 9s
```

So I added `engines` field to `functions/functions/package.json`.
I confirmed `firebase deploy` succeeds after fixing it.