### PR TITLE
Remove link to demo on Chrome Web Store

### DIFF
--- a/auth/chromextension/README.md
+++ b/auth/chromextension/README.md
@@ -3,8 +3,6 @@ Firebase Auth w/ Google Sign-In in Chrome Extensions
 
 This sample demonstrates how to authorize a user with Firebase in a Chrome extension using Google Sign-In and setup the Chrome extension to allow the use of the Realtime Database and Firebase Storage.
 
-Feel free to try out a demo version of the Chrome Extension directly: https://chrome.google.com/webstore/detail/firebase-auth-in-chrome-e/ehflheedljfngcklcnigfonmllgkadbb
-
 Introduction
 ------------
 


### PR DESCRIPTION
"Try out a demo version" section links to a Chrome extension on the Chrome Web Store that I un-published today. This change removes the section about a demo.

#285 Earlier this year the [original demo](https://chrome.google.com/webstore/detail/lpgchdfbjddonaolofeijjackhnhnlla) URL got replaced.

🚨 Both links are currently broken. If you have another demo hosted somewhere you can use that URL instead.