### PR TITLE
Update firebase-messaging-sw.js

### DIFF
--- a/messaging/firebase-messaging-sw.js
+++ b/messaging/firebase-messaging-sw.js
@@ -1,8 +1,8 @@
 // Import and configure the Firebase SDK
 // These scripts are made available when the app is served or deployed on Firebase Hosting
 // If you do not serve/host your project using Firebase Hosting see https://firebase.google.com/docs/web/setup
-importScripts('/__/firebase/6.3.4/firebase-app.js');
-importScripts('/__/firebase/6.3.4/firebase-messaging.js');
+importScripts('/__/firebase/7.3.0/firebase-app.js');
+importScripts('/__/firebase/7.3.0/firebase-messaging.js');
 importScripts('/__/firebase/init.js');
 
 const messaging = firebase.messaging();
@@ -15,8 +15,8 @@ const messaging = firebase.messaging();
  // Give the service worker access to Firebase Messaging.
  // Note that you can only use Firebase Messaging here, other Firebase libraries
  // are not available in the service worker.
- importScripts('https://www.gstatic.com/firebasejs/6.3.4/firebase-app.js');
- importScripts('https://www.gstatic.com/firebasejs/6.3.4/firebase-messaging.js');
+ importScripts('https://www.gstatic.com/firebasejs/7.3.0/firebase-app.js');
+ importScripts('https://www.gstatic.com/firebasejs/7.3.0/firebase-messaging.js');
 
  // Initialize the Firebase app in the service worker by passing in the
  // messagingSenderId.


### PR DESCRIPTION
Import versions of firebase-app.js and firebase-messaging.js differed accross index.html and firebase-messaging-sw.js which caused messaging.onMessage() to not fire in index.html.