### PR TITLE
Add create web app step to messaging

### DIFF
--- a/messaging/README.md
+++ b/messaging/README.md
@@ -13,7 +13,10 @@ Introduction
 Getting Started
 ---------------
 
-1. Create your project on the [Firebase Console](https://console.firebase.google.com).
+1. Create your project in the Firebase Console by following [**Step 1: Create a Firebase Project**](https://firebase.google.com/docs/web/setup/#create-firebase-project)
+1. Register a web app by following [**Step 2: Register your app with Firebase**](https://firebase.google.com/docs/web/setup/#create-firebase-project).
+     1. You don't need to add Hosting right now, and you can skip the "Add Firebase SDK" step in the console's "Add Firebase to your web app" flow.
+     1. Remember to click "Register App" or "Continue to console" at the bottom of the "Add Firebase to your web app" flow.
 1. Open Project and go to **Project settings > Cloud Messaging** and there in section **Web configuration** click **Generate key pair** button.
 1. Copy public key and in `index.html` file replace `<YOUR_PUBLIC_VAPID_KEY_HERE>` with your key.
 1. You must have the [Firebase CLI](https://firebase.google.com/docs/cli/) installed. If you don't have it install it with `npm install -g firebase-tools` and then configure it with `firebase login`.


### PR DESCRIPTION
fixes #413 

If a web app isn't registered before running the messaging quickstart, the code will crash because it is missing the `appId` field in the firebase config object.