### PR TITLE
Fix FCM service worker setup code for >= 7.0.0.

### DIFF
--- a/messaging/firebase-messaging-sw.js
+++ b/messaging/firebase-messaging-sw.js
@@ -19,9 +19,12 @@ const messaging = firebase.messaging();
  importScripts('https://www.gstatic.com/firebasejs/7.9.1/firebase-messaging.js');
 
  // Initialize the Firebase app in the service worker by passing in the
- // messagingSenderId.
+ // apiKey, projectId, messagingSenderId and appId values.
  firebase.initializeApp({
-   'messagingSenderId': 'YOUR-SENDER-ID'
+   'apiKey': 'YOUR-API-KEY',
+   'projectId': 'YOUR-PROJECT-ID',
+   'messagingSenderId': 'YOUR-SENDER-ID',
+   'appId': 'YOUR-APP-ID'
  });
 
  // Retrieve an instance of Firebase Messaging so that it can handle background

--- a/messaging/firebase-messaging-sw.js
+++ b/messaging/firebase-messaging-sw.js
@@ -18,13 +18,18 @@ const messaging = firebase.messaging();
  importScripts('https://www.gstatic.com/firebasejs/7.9.1/firebase-app.js');
  importScripts('https://www.gstatic.com/firebasejs/7.9.1/firebase-messaging.js');
 
- // Initialize the Firebase app in the service worker by passing in the
- // apiKey, projectId, messagingSenderId and appId values.
+ // Initialize the Firebase app in the service worker by passing in
+ // your app's Firebase config object.
+ // https://firebase.google.com/docs/web/setup#config-object
  firebase.initializeApp({
-   'apiKey': 'YOUR-API-KEY',
-   'projectId': 'YOUR-PROJECT-ID',
-   'messagingSenderId': 'YOUR-SENDER-ID',
-   'appId': 'YOUR-APP-ID'
+   apiKey: 'api-key',
+   authDomain: 'project-id.firebaseapp.com',
+   databaseURL: 'https://project-id.firebaseio.com',
+   projectId: 'project-id',
+   storageBucket: 'project-id.appspot.com',
+   messagingSenderId: 'sender-id',
+   appId: 'app-id',
+   measurementId: 'G-measurement-id',
  });
 
  // Retrieve an instance of Firebase Messaging so that it can handle background


### PR DESCRIPTION
Update the FCM service worker setup code to work with >=7.0.0 Firebase JavaScript SDK. There was a major change in `v7.0.0` as mentioned in the [release notes](https://firebase.google.com/support/release-notes/js#version_700_-_september_26_2019).

The same has been also acknowledged in this [firebase-js-sdk](https://github.com/firebase/firebase-js-sdk/issues/2287#issuecomment-553860831) issue.

PS - I am not sure if the comment I have updated in this PR is used to render the [official firebase.google.com docs](https://firebase.google.com/docs/cloud-messaging/js/receive#handle_messages_when_your_web_app_is_in_the_foreground) but looking at the metadata around the comment and noticing that `firebase.google.com`code block links to this commented code, I am guessing that's the case.