### PR TITLE
Update README.md

### DIFF
--- a/firestore/README.md
+++ b/firestore/README.md
@@ -13,7 +13,7 @@ Follow these steps to setup and run the quickstart:
 
  1. Create a Firebase project in the [Firebase Console](https://console.firebase.google.com).
  1. In the Firebase console, enable Anonymous authentication on your project by doing: **Authentication > SIGN-IN METHOD > Anonymous > Enable > SAVE**
- 1. In the Firebase console, enable Cloud Firestore on your project by doing: **Database > Create Database**
+ 1. In the Firebase console, enable Cloud Firestore on your project by doing: **Database > Create Database** and define the database location
  1. Select testing mode for the security rules
  1. Copy/Download this repo and open this folder in a Terminal.
  1. Install the Firebase CLI if you do not have it installed on your machine:

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -13,8 +13,8 @@ Follow these steps to setup and run the quickstart:
 
  1. Create a Firebase project in the [Firebase Console](https://console.firebase.google.com).
  1. In the Firebase console, enable Anonymous authentication on your project by doing: **Authentication > SIGN-IN METHOD > Anonymous > Enable > SAVE**
- 1. In the Firebase console, enable Cloud Firestore on your project by doing: **Database > Create Database** and define the database location
- 1. Select testing mode for the security rules
+ 1. In the Firebase console, enable Cloud Firestore on your project by doing: **Database > Create Database** and answer all prompts.
+     1. Select testing mode for the security rules
  1. Copy/Download this repo and open this folder in a Terminal.
  1. Install the Firebase CLI if you do not have it installed on your machine:
     ```bash


### PR DESCRIPTION
Without specifying location it didn't let me deploy it (and I got a HTTP 404 error). 

The location of the database (resource location ID) should also be specified (in the Firebase Cloudstore settings). 