### PR TITLE
Remove auth snippets, move to snippets-web

### DIFF
--- a/auth/anon.html
+++ b/auth/anon.html
@@ -41,24 +41,18 @@ limitations under the License.
      */
     function toggleSignIn() {
       if (firebase.auth().currentUser) {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       } else {
-        // [START authanon]
         firebase.auth().signInAnonymously().catch(function(error) {
           // Handle Errors here.
           var errorCode = error.code;
           var errorMessage = error.message;
-          // [START_EXCLUDE]
           if (errorCode === 'auth/operation-not-allowed') {
             alert('You must enable Anonymous auth in the Firebase Console.');
           } else {
             console.error(error);
           }
-          // [END_EXCLUDE]
         });
-        // [END authanon]
       }
       document.getElementById('quickstart-sign-in').disabled = true;
     }
@@ -71,30 +65,22 @@ limitations under the License.
      */
     function initApp() {
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign in';
           document.getElementById('quickstart-account-details').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/apple-popup.html
+++ b/auth/apple-popup.html
@@ -98,9 +98,7 @@ limitations under the License.
             });
           // [END signin]
         } else {
-          // [START signout]
           firebase.auth().signOut();
-          // [END signout]
         }
         // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = true;
@@ -115,7 +113,6 @@ limitations under the License.
        */
       function initApp() {
         // Listening for auth state changes.
-        // [START authstatelistener]
         firebase.auth().onAuthStateChanged(function(user) {
           if (user) {
             // User is signed in. Note that unlike other providers supported by Firebase Auth, Apple does
@@ -126,7 +123,6 @@ limitations under the License.
             var isAnonymous = user.isAnonymous;
             var uid = user.uid;
             var providerData = user.providerData;
-            // [START_EXCLUDE]
             document.getElementById('quickstart-sign-in-status').textContent =
               'Signed in';
             document.getElementById('quickstart-sign-in').textContent =
@@ -134,10 +130,8 @@ limitations under the License.
             document.getElementById(
               'quickstart-account-details'
             ).textContent = JSON.stringify(user, null, '  ');
-            // [END_EXCLUDE]
           } else {
             // User is signed out.
-            // [START_EXCLUDE]
             document.getElementById('quickstart-sign-in-status').textContent =
               'Signed out';
             document.getElementById('quickstart-sign-in').textContent =
@@ -146,13 +140,9 @@ limitations under the License.
               'null';
             document.getElementById('quickstart-oauthtoken').textContent =
               'null';
-            // [END_EXCLUDE]
           }
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in').disabled = false;
-          // [END_EXCLUDE]
         });
-        // [END authstatelistener]
 
         document
           .getElementById('quickstart-sign-in')

--- a/auth/apple-redirect.html
+++ b/auth/apple-redirect.html
@@ -58,9 +58,7 @@ limitations under the License.
           firebase.auth().signInWithRedirect(provider);
           // [END signin]
         } else {
-          // [START signout]
           firebase.auth().signOut();
-          // [END signout]
         }
         // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = true;
@@ -122,7 +120,6 @@ limitations under the License.
         // [END getidptoken]
 
         // Listening for auth state changes.
-        // [START authstatelistener]
         firebase.auth().onAuthStateChanged(function(user) {
           if (user) {
             // User is signed in. Note that unlike other providers supported by Firebase Auth, Apple does
@@ -133,7 +130,6 @@ limitations under the License.
             var isAnonymous = user.isAnonymous;
             var uid = user.uid;
             var providerData = user.providerData;
-            // [START_EXCLUDE]
             document.getElementById('quickstart-sign-in-status').textContent =
               'Signed in';
             document.getElementById('quickstart-sign-in').textContent =
@@ -141,10 +137,8 @@ limitations under the License.
             document.getElementById(
               'quickstart-account-details'
             ).textContent = JSON.stringify(user, null, '  ');
-            // [END_EXCLUDE]
           } else {
             // User is signed out.
-            // [START_EXCLUDE]
             document.getElementById('quickstart-sign-in-status').textContent =
               'Signed out';
             document.getElementById('quickstart-sign-in').textContent =
@@ -153,13 +147,9 @@ limitations under the License.
               'null';
             document.getElementById('quickstart-oauthtoken').textContent =
               'null';
-            // [END_EXCLUDE]
           }
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in').disabled = false;
-          // [END_EXCLUDE]
         });
-        // [END authstatelistener]
 
         document
           .getElementById('quickstart-sign-in')

--- a/auth/chromextension/credentials.js
+++ b/auth/chromextension/credentials.js
@@ -23,7 +23,6 @@ firebase.initializeApp(config);
  */
 function initApp() {
   // Listen for auth state changes.
-  // [START authstatelistener]
   firebase.auth().onAuthStateChanged(function(user) {
     if (user) {
       // User is signed in.
@@ -34,22 +33,17 @@ function initApp() {
       var isAnonymous = user.isAnonymous;
       var uid = user.uid;
       var providerData = user.providerData;
-      // [START_EXCLUDE]
       document.getElementById('quickstart-button').textContent = 'Sign out';
       document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
       document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-      // [END_EXCLUDE]
     } else {
       // Let's try to get a Google auth token programmatically.
-      // [START_EXCLUDE]
       document.getElementById('quickstart-button').textContent = 'Sign-in with Google';
       document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
       document.getElementById('quickstart-account-details').textContent = 'null';
-      // [END_EXCLUDE]
     }
     document.getElementById('quickstart-button').disabled = false;
   });
-  // [END authstatelistener]
 
   document.getElementById('quickstart-button').addEventListener('click', startSignIn, false);
 }

--- a/auth/customauth.html
+++ b/auth/customauth.html
@@ -41,9 +41,7 @@ limitations under the License.
      */
     function toggleSignIn() {
       if (firebase.auth().currentUser) {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       } else {
         var token = document.getElementById('tokentext').value;
         if (token.length < 10) {
@@ -51,20 +49,16 @@ limitations under the License.
           return;
         }
         // Sign in with custom token generated following previous instructions.
-        // [START authwithtoken]
         firebase.auth().signInWithCustomToken(token).catch(function(error) {
           // Handle Errors here.
           var errorCode = error.code;
           var errorMessage = error.message;
-          // [START_EXCLUDE]
           if (errorCode === 'auth/invalid-custom-token') {
             alert('The token you provided is not valid.');
           } else {
             console.error(error);
           }
-          // [END_EXCLUDE]
         });
-        // [END authwithtoken]
       }
       document.getElementById('quickstart-sign-in').disabled = true;
     }
@@ -77,7 +71,6 @@ limitations under the License.
      */
     function initApp() {
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -88,24 +81,17 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign in';
           document.getElementById('quickstart-account-details').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/email-link.html
+++ b/auth/email-link.html
@@ -44,20 +44,15 @@ limitations under the License.
       document.getElementById('quickstart-sign-in').disabled = true;
 
       if (firebase.auth().currentUser) {
-        // [START signout]
         firebase.auth().signOut().catch(function(error) {
           // Handle Errors here.
           var errorCode = error.code;
           var errorMessage = error.message;
-          // [START_EXCLUDE]
           handleError(error);
-          // [END_EXCLUDE]
         });
-        // [END signout]
       } else {
         var email = document.getElementById('email').value;
         // Sending email with sign-in link.
-        // [START authwithemail]
         var actionCodeSettings = {
           // URL you want to redirect back to. The domain (www.example.com) for this URL
           // must be whitelisted in the Firebase Console.
@@ -71,19 +66,14 @@ limitations under the License.
           window.localStorage.setItem('emailForSignIn', email);
           // The link was successfully sent. Inform the user.
           alert('An email was sent to ' + email + '. Please use the link in the email to sign-in.');
-          // [START_EXCLUDE]
           // Re-enable the sign-in button.
           document.getElementById('quickstart-sign-in').disabled = false;
-          // [END_EXCLUDE]
         }).catch(function(error) {
           // Handle Errors here.
           var errorCode = error.code;
           var errorMessage = error.message;
-          // [START_EXCLUDE]
           handleError(error);
-          // [END_EXCLUDE]
         });
-        // [END authwithemail]
       }
     }
 
@@ -102,12 +92,9 @@ limitations under the License.
      * Handles automatically signing-in the app if we clicked on the sign-in link in the email.
      */
     function handleSignIn() {
-      // [START handlesignin]
       if (firebase.auth().isSignInWithEmailLink(window.location.href)) {
-        // [START_EXCLUDE]
         // Disable the sign-in button during async sign-in tasks.
         document.getElementById('quickstart-sign-in').disabled = true;
-        // [END_EXCLUDE]
 
         // You can also get the other parameters passed in the query string such as state=STATE.
         // Get the email if available.
@@ -134,13 +121,10 @@ limitations under the License.
             // Handle Errors here.
             var errorCode = error.code;
             var errorMessage = error.message;
-            // [START_EXCLUDE]
             handleError(error);
-            // [END_EXCLUDE]
           });
         }
       }
-      // [END handlesignin]
     }
 
     /**
@@ -157,7 +141,6 @@ limitations under the License.
       handleSignIn();
 
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -169,25 +152,18 @@ limitations under the License.
           var uid = user.uid;
           var providerData = user.providerData;
           // Update UI.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
           // Update UI.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign In without password';
           document.getElementById('quickstart-account-details').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE silent]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/email-password.html
+++ b/auth/email-password.html
@@ -41,9 +41,7 @@ limitations under the License.
      */
     function toggleSignIn() {
       if (firebase.auth().currentUser) {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       } else {
         var email = document.getElementById('email').value;
         var password = document.getElementById('password').value;
@@ -56,12 +54,10 @@ limitations under the License.
           return;
         }
         // Sign in with email and pass.
-        // [START authwithemail]
         firebase.auth().signInWithEmailAndPassword(email, password).catch(function(error) {
           // Handle Errors here.
           var errorCode = error.code;
           var errorMessage = error.message;
-          // [START_EXCLUDE]
           if (errorCode === 'auth/wrong-password') {
             alert('Wrong password.');
           } else {
@@ -69,9 +65,7 @@ limitations under the License.
           }
           console.log(error);
           document.getElementById('quickstart-sign-in').disabled = false;
-          // [END_EXCLUDE]
         });
-        // [END authwithemail]
       }
       document.getElementById('quickstart-sign-in').disabled = true;
     }
@@ -91,59 +85,45 @@ limitations under the License.
         return;
       }
       // Create user with email and pass.
-      // [START createwithemail]
       firebase.auth().createUserWithEmailAndPassword(email, password).catch(function(error) {
         // Handle Errors here.
         var errorCode = error.code;
         var errorMessage = error.message;
-        // [START_EXCLUDE]
         if (errorCode == 'auth/weak-password') {
           alert('The password is too weak.');
         } else {
           alert(errorMessage);
         }
         console.log(error);
-        // [END_EXCLUDE]
       });
-      // [END createwithemail]
     }
 
     /**
      * Sends an email verification to the user.
      */
     function sendEmailVerification() {
-      // [START sendemailverification]
       firebase.auth().currentUser.sendEmailVerification().then(function() {
         // Email Verification sent!
-        // [START_EXCLUDE]
         alert('Email Verification Sent!');
-        // [END_EXCLUDE]
       });
-      // [END sendemailverification]
     }
 
     function sendPasswordReset() {
       var email = document.getElementById('email').value;
-      // [START sendpasswordemail]
       firebase.auth().sendPasswordResetEmail(email).then(function() {
         // Password Reset Email Sent!
-        // [START_EXCLUDE]
         alert('Password Reset Email Sent!');
-        // [END_EXCLUDE]
       }).catch(function(error) {
         // Handle Errors here.
         var errorCode = error.code;
         var errorMessage = error.message;
-        // [START_EXCLUDE]
         if (errorCode == 'auth/invalid-email') {
           alert(errorMessage);
         } else if (errorCode == 'auth/user-not-found') {
           alert(errorMessage);
         }
         console.log(error);
-        // [END_EXCLUDE]
       });
-      // [END sendpasswordemail];
     }
 
     /**
@@ -153,11 +133,8 @@ limitations under the License.
      */
     function initApp() {
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
-        // [START_EXCLUDE silent]
         document.getElementById('quickstart-verify-email').disabled = true;
-        // [END_EXCLUDE]
         if (user) {
           // User is signed in.
           var displayName = user.displayName;
@@ -167,25 +144,19 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
           if (!emailVerified) {
             document.getElementById('quickstart-verify-email').disabled = false;
           }
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign in';
           document.getElementById('quickstart-account-details').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE silent]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
       // [END authstatelistener]
 

--- a/auth/facebook-credentials.html
+++ b/auth/facebook-credentials.html
@@ -77,7 +77,6 @@ limitations under the License.
     /**
      * Function called when there is a change in Facebook auth state.
      */
-    // [START facebookcallback]
     function checkLoginState(event) {
       if (event.authResponse) {
         // User is signed-in Facebook.
@@ -86,12 +85,9 @@ limitations under the License.
           // Check if we are already signed-in Firebase with the correct user.
           if (!isUserEqual(event.authResponse, firebaseUser)) {
             // Build Firebase credential with the Facebook auth token.
-            // [START facebookcredential]
             var credential = firebase.auth.FacebookAuthProvider.credential(
                 event.authResponse.accessToken);
-            // [END facebookcredential]
             // Sign in with the credential from the Facebook user.
-            // [START authwithcred]
             firebase.auth().signInWithCredential(credential).catch(function(error) {
               // Handle Errors here.
               var errorCode = error.code;
@@ -100,7 +96,6 @@ limitations under the License.
               var email = error.email;
               // The firebase.auth.AuthCredential type that was used.
               var credential = error.credential;
-              // [START_EXCLUDE]
               if (errorCode === 'auth/account-exists-with-different-credential') {
                 alert('You have already signed up with a different auth provider for that email.');
                 // If you are using multiple auth providers on your app you should handle linking
@@ -108,18 +103,14 @@ limitations under the License.
               } else {
                 console.error(error);
               }
-              // [END_EXCLUDE]
             });
-            // [END authwithcred]
           } else {
             // User is already signed-in Firebase with the correct user.
           }
         });
       } else {
         // User is signed-out of Facebook.
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
     }
     // [END facebookcallback]
@@ -127,7 +118,6 @@ limitations under the License.
     /**
      * Check that the given Facebook user is equals to the  given Firebase user
      */
-    // [START checksameuser]
     function isUserEqual(facebookAuthResponse, firebaseUser) {
       if (firebaseUser) {
         var providerData = firebaseUser.providerData;
@@ -141,7 +131,6 @@ limitations under the License.
       }
       return false;
     }
-    // [END checksameuser]
 
 
     /**
@@ -151,7 +140,6 @@ limitations under the License.
      */
     function initApp() {
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -162,19 +150,14 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-account-details').textContent = 'null';
-          // [END_EXCLUDE]
         }
       });
-      // [END authstatelistener]
     }
 
     initApp();

--- a/auth/facebook-popup.html
+++ b/auth/facebook-popup.html
@@ -77,9 +77,7 @@ limitations under the License.
         });
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -94,7 +92,6 @@ limitations under the License.
      */
     function initApp() {
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -105,25 +102,18 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Log out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Log in with Facebook';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/facebook-redirect.html
+++ b/auth/facebook-redirect.html
@@ -52,9 +52,7 @@ limitations under the License.
         firebase.auth().signInWithRedirect(provider);
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -105,7 +103,6 @@ limitations under the License.
       // [END getidptoken]
 
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -116,25 +113,18 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Log out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Log in with Facebook';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/github-popup.html
+++ b/auth/github-popup.html
@@ -77,9 +77,7 @@ limitations under the License.
         });
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -95,7 +93,6 @@ limitations under the License.
      */
     function initApp() {
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -106,25 +103,18 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign in with GitHub';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/github-redirect.html
+++ b/auth/github-redirect.html
@@ -52,9 +52,7 @@ limitations under the License.
         firebase.auth().signInWithRedirect(provider);
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -105,7 +103,6 @@ limitations under the License.
       // [END getidptoken]
 
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -116,25 +113,18 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign in with GitHub';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/google-credentials.html
+++ b/auth/google-credentials.html
@@ -57,7 +57,6 @@ limitations under the License.
 
   <script type="text/javascript">
 
-    // [START googlecallback]
     function onSignIn(googleUser) {
       console.log('Google Auth Response', googleUser);
       // We need to register an Observer on Firebase Auth to make sure auth is initialized.
@@ -66,12 +65,10 @@ limitations under the License.
         // Check if we are already signed-in Firebase with the correct user.
         if (!isUserEqual(googleUser, firebaseUser)) {
           // Build Firebase credential with the Google ID token.
-          // [START googlecredential]
           var credential = firebase.auth.GoogleAuthProvider.credential(
               googleUser.getAuthResponse().id_token);
-          // [END googlecredential]
+
           // Sign in with credential from the Google user.
-          // [START authwithcred]
           firebase.auth().signInWithCredential(credential).catch(function(error) {
             // Handle Errors here.
             var errorCode = error.code;
@@ -80,7 +77,6 @@ limitations under the License.
             var email = error.email;
             // The firebase.auth.AuthCredential type that was used.
             var credential = error.credential;
-            // [START_EXCLUDE]
             if (errorCode === 'auth/account-exists-with-different-credential') {
               alert('You have already signed up with a different auth provider for that email.');
               // If you are using multiple auth providers on your app you should handle linking
@@ -88,20 +84,16 @@ limitations under the License.
             } else {
               console.error(error);
             }
-            // [END_EXCLUDE]
           });
-          // [END authwithcred]
         } else {
           console.log('User already signed-in Firebase.');
         }
       });
     }
-    // [END googlecallback]
-
+    
     /**
      * Check that the given Google user is equals to the given Firebase user.
      */
-    // [START checksameuser]
     function isUserEqual(googleUser, firebaseUser) {
       if (firebaseUser) {
         var providerData = firebaseUser.providerData;
@@ -115,7 +107,6 @@ limitations under the License.
       }
       return false;
     }
-    // [END checksameuser]
 
     /**
      * Handle the sign out button press.

--- a/auth/google-credentials.html
+++ b/auth/google-credentials.html
@@ -135,7 +135,6 @@ limitations under the License.
      */
     function initApp() {
       // Auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user){
         if (user) {
           // User is signed in.
@@ -146,21 +145,16 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('signout').disabled = false;
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('signout').disabled = true;
           document.getElementById('quickstart-account-details').textContent = 'null';
-            // [END_EXCLUDE]
         }
       });
-      // [END authstatelistener]
 
       document.getElementById('signout').addEventListener('click', handleSignOut, false);
     }

--- a/auth/google-popup.html
+++ b/auth/google-popup.html
@@ -77,9 +77,7 @@ limitations under the License.
         });
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -94,7 +92,6 @@ limitations under the License.
      */
     function initApp() {
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -105,25 +102,18 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign in with Google';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/google-redirect.html
+++ b/auth/google-redirect.html
@@ -52,9 +52,7 @@ limitations under the License.
         firebase.auth().signInWithRedirect(provider);
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -106,7 +104,6 @@ limitations under the License.
       // [END getidptoken]
 
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -117,25 +114,18 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign in with Google';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/microsoft-popup.html
+++ b/auth/microsoft-popup.html
@@ -80,9 +80,7 @@ limitations under the License.
         });
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -97,7 +95,6 @@ limitations under the License.
      */
     function initApp() {
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in. Note that unlike other providers supported by Firebase Auth, Microsoft does
@@ -109,25 +106,18 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Log out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Log in with Microsoft';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/microsoft-redirect.html
+++ b/auth/microsoft-redirect.html
@@ -52,9 +52,7 @@ limitations under the License.
         firebase.auth().signInWithRedirect(provider);
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -107,7 +105,6 @@ limitations under the License.
       // [END getidptoken]
 
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in. Note that unlike other providers supported by Firebase Auth, Microsoft does
@@ -119,25 +116,18 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Log out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Log in with Microsoft';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/twitter-popup.html
+++ b/auth/twitter-popup.html
@@ -77,9 +77,7 @@ limitations under the License.
         });
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -95,7 +93,6 @@ limitations under the License.
      */
     function initApp() {
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -106,26 +103,19 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign in with Twitter';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
           document.getElementById('quickstart-oauthsecret').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }

--- a/auth/twitter-redirect.html
+++ b/auth/twitter-redirect.html
@@ -49,9 +49,7 @@ limitations under the License.
         firebase.auth().signInWithRedirect(provider);
         // [END signin]
       } else {
-        // [START signout]
         firebase.auth().signOut();
-        // [END signout]
       }
       // [START_EXCLUDE]
       document.getElementById('quickstart-sign-in').disabled = true;
@@ -106,7 +104,6 @@ limitations under the License.
       // [END getidptoken]
 
       // Listening for auth state changes.
-      // [START authstatelistener]
       firebase.auth().onAuthStateChanged(function(user) {
         if (user) {
           // User is signed in.
@@ -117,26 +114,19 @@ limitations under the License.
           var isAnonymous = user.isAnonymous;
           var uid = user.uid;
           var providerData = user.providerData;
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed in';
           document.getElementById('quickstart-sign-in').textContent = 'Sign out';
           document.getElementById('quickstart-account-details').textContent = JSON.stringify(user, null, '  ');
-          // [END_EXCLUDE]
         } else {
           // User is signed out.
-          // [START_EXCLUDE]
           document.getElementById('quickstart-sign-in-status').textContent = 'Signed out';
           document.getElementById('quickstart-sign-in').textContent = 'Sign in with Twitter';
           document.getElementById('quickstart-account-details').textContent = 'null';
           document.getElementById('quickstart-oauthtoken').textContent = 'null';
           document.getElementById('quickstart-oauthsecret').textContent = 'null';
-          // [END_EXCLUDE]
         }
-        // [START_EXCLUDE]
         document.getElementById('quickstart-sign-in').disabled = false;
-        // [END_EXCLUDE]
       });
-      // [END authstatelistener]
 
       document.getElementById('quickstart-sign-in').addEventListener('click', toggleSignIn, false);
     }


### PR DESCRIPTION
See:
  - https://github.com/firebase/snippets-web/pull/57
  - https://github.com/firebase/snippets-web/pull/58

As part of the move to the new JS SDKs it will be *much* easier if all of the snippets are in `snippets-web`, so I am going to start migrating them.