### PR TITLE
Remove remaining snippet tags

### DIFF
--- a/database/scripts/main.js
+++ b/database/scripts/main.js
@@ -351,17 +351,13 @@ function onAuthStateChanged(user) {
  * Creates a new post for the current user.
  */
 function newPostForCurrentUser(title, text) {
-  // [START single_value_read]
   var userId = firebase.auth().currentUser.uid;
   return firebase.database().ref('/users/' + userId).once('value').then(function(snapshot) {
     var username = (snapshot.val() && snapshot.val().username) || 'Anonymous';
-    // [START_EXCLUDE]
     return writeNewPost(firebase.auth().currentUser.uid, username,
       firebase.auth().currentUser.photoURL,
       title, text);
-    // [END_EXCLUDE]
   });
-  // [END single_value_read]
 }
 
 /**

--- a/messaging/firebase-messaging-sw.js
+++ b/messaging/firebase-messaging-sw.js
@@ -11,7 +11,6 @@ const messaging = firebase.messaging();
  * Here is is the code snippet to initialize Firebase Messaging in the Service
  * Worker when your app is not hosted on Firebase Hosting.
 
- // [START initialize_firebase_in_sw]
  // Give the service worker access to Firebase Messaging.
  // Note that you can only use Firebase Messaging here. Other Firebase libraries
  // are not available in the service worker.
@@ -35,14 +34,12 @@ const messaging = firebase.messaging();
  // Retrieve an instance of Firebase Messaging so that it can handle background
  // messages.
  const messaging = firebase.messaging();
- // [END initialize_firebase_in_sw]
  **/
 
 
 // If you would like to customize notifications that are received in the
 // background (Web app is closed or not in browser focus) then you should
 // implement this optional method.
-// [START on_background_message]
 messaging.onBackgroundMessage(function(payload) {
   console.log('[firebase-messaging-sw.js] Received background message ', payload);
   // Customize notification here
@@ -55,4 +52,3 @@ messaging.onBackgroundMessage(function(payload) {
   self.registration.showNotification(notificationTitle,
     notificationOptions);
 });
-// [END on_background_message]

--- a/messaging/index.html
+++ b/messaging/index.html
@@ -77,33 +77,26 @@ limitations under the License.
 <script src="/__/firebase/init.js"></script>
 
 <script>
-  // [START get_messaging_object]
   // Retrieve Firebase Messaging object.
   const messaging = firebase.messaging();
-  // [END get_messaging_object]
 
   // IDs of divs that display registration token UI or request permission UI.
   const tokenDivId = 'token_div';
   const permissionDivId = 'permission_div';
 
-  // [START receive_message]
   // Handle incoming messages. Called when:
   // - a message is received while the app has focus
   // - the user clicks on an app notification created by a service worker
   //   `messaging.onBackgroundMessage` handler.
   messaging.onMessage((payload) => {
     console.log('Message received. ', payload);
-    // [START_EXCLUDE]
     // Update the UI to include the received message.
     appendMessage(payload);
-    // [END_EXCLUDE]
   });
-  // [END receive_message]
 
   function resetUI() {
     clearMessages();
     showToken('loading...');
-    // [START get_token]
     // Get registration token. Initially this makes a network call, once retrieved
     // subsequent calls to getToken will return from cache.
     messaging.getToken({vapidKey: '<YOUR_PUBLIC_VAPID_KEY_HERE>'}).then((currentToken) => {
@@ -122,7 +115,6 @@ limitations under the License.
       showToken('Error retrieving registration token. ', err);
       setTokenSentToServer(false);
     });
-    // [END get_token]
   }
 
 
@@ -165,38 +157,30 @@ limitations under the License.
 
   function requestPermission() {
     console.log('Requesting permission...');
-    // [START request_permission]
     Notification.requestPermission().then((permission) => {
       if (permission === 'granted') {
         console.log('Notification permission granted.');
         // TODO(developer): Retrieve a registration token for use with FCM.
-        // [START_EXCLUDE]
         // In many cases once an app has been granted notification permission,
         // it should update its UI reflecting this.
         resetUI();
-        // [END_EXCLUDE]
       } else {
         console.log('Unable to get permission to notify.');
       }
     });
-    // [END request_permission]
   }
 
   function deleteToken() {
     // Delete registration token.
-    // [START delete_token]
     messaging.getToken().then((currentToken) => {
       messaging.deleteToken(currentToken).then(() => {
         console.log('Token deleted.');
         setTokenSentToServer(false);
-        // [START_EXCLUDE]
         // Once token is deleted update UI.
         resetUI();
-        // [END_EXCLUDE]
       }).catch((err) => {
         console.log('Unable to delete token. ', err);
       });
-      // [END delete_token]
     }).catch((err) => {
       console.log('Error retrieving registration token. ', err);
       showToken('Error retrieving registration token. ', err);

--- a/storage/index.html
+++ b/storage/index.html
@@ -81,23 +81,17 @@ limitations under the License.
       };
 
       // Push to child path.
-      // [START oncomplete]
       storageRef.child('images/' + file.name).put(file, metadata).then(function(snapshot) {
         console.log('Uploaded', snapshot.totalBytes, 'bytes.');
         console.log('File metadata:', snapshot.metadata);
         // Let's get a download URL for the file.
         snapshot.ref.getDownloadURL().then(function(url) {
           console.log('File available at', url);
-          // [START_EXCLUDE]
           document.getElementById('linkbox').innerHTML = '<a href="' +  url + '">Click For File</a>';
-          // [END_EXCLUDE]
         });
       }).catch(function(error) {
-        // [START onfailure]
         console.error('Upload failed:', error);
-        // [END onfailure]
       });
-      // [END oncomplete]
     }
 
     window.onload = function() {


### PR DESCRIPTION
This is the final move of snippets from quickstart-js to snippets-web

See:
https://github.com/firebase/snippets-web/pull/86

The only snippets which remain here are:
  * Google and Facebook Auth snippets which are in HTML and not related to the Firebase SDK
  * Some functions snippets which should probably be in snippets-node or functions-samples