### PR TITLE
Add `standalone` config so the qucikstart is compatible with iOS & padOS Safari

### DIFF
--- a/messaging/manifest.json
+++ b/messaging/manifest.json
@@ -1,5 +1,6 @@
 {
   "//_comment1": "Some browsers will use this to enable push notifications.",
   "//_comment2": "It is the same for all projects, this is not your project's sender ID",
-  "gcm_sender_id": "103953800507"
+  "gcm_sender_id": "103953800507",
+  "display": "standalone"
 }


### PR DESCRIPTION
instruction per https://webkit.org/blog/13878/web-push-for-web-apps-on-ios-and-ipados/