### PR TITLE
Fix CI by removing extra Lerna install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          npm install -g lerna
-          lerna bootstrap
+          npm run bootstrap
       
       - name: Run tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lerna": "^6.6.1"
   },
   "scripts": {
+    "bootstrap": "lerna bootstrap",
     "test": "scripts/test.sh"
   }
 }


### PR DESCRIPTION
Correct version of Lerna is declared in `devDependencies`, so we should use that in CI instead of `npm i -g lerna`, which always pulls in the latest version.