### PR TITLE
Added UI flag to Emulator Scripts

### DIFF
--- a/firestore/angular-rewrite/package.json
+++ b/firestore/angular-rewrite/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "npm run pre-build && firebase --project demo-friendly-eats emulators:exec --import ./imported-firebase-data 'ng serve'",
-    "emulators": "npm run pre-build && firebase --project demo-friendly-eats emulators:exec --import ./imported-firebase-data 'ng serve -c local'",
+    "start": "npm run pre-build && firebase --project demo-friendly-eats emulators:exec --import ./imported-firebase-data --ui 'ng serve'",
+    "emulators": "npm run pre-build && firebase --project demo-friendly-eats emulators:exec --import ./imported-firebase-data --ui 'ng serve -c local'",
     "production": "npm run pre-build && firebase deploy --only firestore && npm run check-config",
     "check-config":"grep -q \"projectId\" \"src/environments/environment.prod.ts\" && ng serve -c production || echo \"No project id in configuration file!\"",
     "pre-build": "(cd functions && npm run build)",


### PR DESCRIPTION
Quick change to add the `--ui` flag to scripts that run the Firebase Emulators so that the Emulator Suite UI will be available on `localhost:4000`.