### PR TITLE
FriendlyEats `launch.json` file

### DIFF
--- a/firestore/angular-rewrite/.gitignore
+++ b/firestore/angular-rewrite/.gitignore
@@ -47,5 +47,4 @@ Thumbs.db
 .runtimeconfig.json
 
 # VSCode and editor ignores
-.vscode/*
 .editorconfig

--- a/firestore/angular-rewrite/.vscode/launch.json
+++ b/firestore/angular-rewrite/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.1.0",
+    "configurations": [
+        {
+            "command": "npm start",
+            "type": "node-terminal",
+            "request": "launch",
+            "name": "Launch Quickstart [Emulators]"
+        },
+
+        {
+            "cwd": "${workspaceFolder}",
+            "command": "npm run production",
+            "type": "node-terminal",
+            "request": "launch",
+            "name": "Launch Quickstart [Production]"
+        }
+
+    ]
+}

--- a/firestore/angular-rewrite/.vscode/launch.json
+++ b/firestore/angular-rewrite/.vscode/launch.json
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 {
     "version": "0.1.0",
     "configurations": [


### PR DESCRIPTION
This PR adds a `launch.json` file  to the `.vscode/` directory to allow the quickstart to be launched from the debug window in vscode. Additionally, the `.gitignore` was modified to allow visibility into the `.vscode/` directory.