### PR TITLE
Migrate JavaScript libraries from the earlier Google Sign-In platform…

### DIFF
--- a/auth/google-credentials.html
+++ b/auth/google-credentials.html
@@ -46,7 +46,7 @@ limitations under the License.
   <link rel="stylesheet" href="main.css">
 
   <!-- Google Sign In -->
-  <script src="https://apis.google.com/js/platform.js" async defer></script>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
 
   <!-- Import and configure the Firebase SDK -->
   <!-- These scripts are made available when the app is served or deployed on Firebase Hosting -->
@@ -66,7 +66,7 @@ limitations under the License.
         if (!isUserEqual(googleUser, firebaseUser)) {
           // Build Firebase credential with the Google ID token.
           var credential = firebase.auth.GoogleAuthProvider.credential(
-              googleUser.getAuthResponse().id_token);
+              googleUser.credential);
 
           // Sign in with credential from the Google user.
           firebase.auth().signInWithCredential(credential).catch(function(error) {
@@ -178,7 +178,12 @@ limitations under the License.
         <div class="mdl-card__supporting-text mdl-color-text--grey-600">
           <p>Sign in with your Google account below.</p>
           <!-- [START google_button] -->
-          <div class="g-signin2" data-onsuccess="onSignIn" data-theme="dark"></div>
+          <!-- <div class="g-signin2" data-onsuccess="onSignIn" data-theme="dark"></div> -->
+          <div id="g_id_onload"
+         data-client_id="YOUR_CLIENT_ID"
+         data-callback="onSignIn">
+    </div>
+    <div class="g_id_signin" data-type="standard"></div>
           <!-- [END google_button] -->
           <br>
           <button disabled class="mdl-button mdl-js-button mdl-button--raised" id="signout" name="signout">Sign Out</button>


### PR DESCRIPTION
\Migrate JavaScript libraries from the earlier Google Sign-In platform library to the newer Google Identity Services library for authentication.

Chrome third-party cookie deprecation starts Q1 2024. Refer to the document https://developers.google.com/identity/gsi/web/guides/migration to upgrade