### PR TITLE
Wrap emulator exec script in double quotes

### DIFF
--- a/firestore/package.json
+++ b/firestore/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "npm run pre-build && firebase --project demo-friendly-eats emulators:exec --import ./app-data-seed --ui 'ng serve'",
-    "emulators": "npm run pre-build && firebase --project demo-friendly-eats emulators:exec --import ./app-data-seed --ui 'ng serve -c local'",
+    "start": "npm run pre-build && firebase --project demo-friendly-eats emulators:exec --import ./app-data-seed --ui \"ng serve\"",
+    "emulators": "npm run pre-build && firebase --project demo-friendly-eats emulators:exec --import ./app-data-seed --ui \"ng serve -c local\"",
     "production": "npm run pre-build && firebase deploy --only firestore && npm run check-config",
     "check-config":"grep -q \"projectId\" \"src/environments/environment.prod.ts\" && ng serve -c production || echo \"No project id in configuration file!\"",
     "pre-build": "(cd functions && npm run build)",


### PR DESCRIPTION
Wrap the script argument of `firebase emulators:exec` command.

Related issue https://github.com/firebase/firebase-tools/issues/7476

On a Windows machine, when running the command below, the emulators do not start
```
firebase --project demo-friendly-eats emulators:exec --import ./app-data-seed --ui 'ng serve'
```

Might be related to how Windows treats single quotes https://stackoverflow.com/a/51090074.

Running the command below, emulators were able to start:
```
firebase --project demo-friendly-eats emulators:exec --import ./app-data-seed --ui "ng serve"
```
