### PR TITLE
Add MFA link to the main page

### DIFF
--- a/auth/index.html
+++ b/auth/index.html
@@ -58,6 +58,8 @@ limitations under the License.
             <li><a href="email-password.html">Email and Password authentication</a></li>
             <li><a href="email-link.html">Email Link authentication</a><br><br></li>
             
+            <li><a href="mfa-password.html">SMS multi-factor authentication</a><br><br></li>
+
             <li><a href="customauth.html">Custom Authentication</a> and an Example <a href="exampletokengenerator/auth.html">Custom Token Generator</a><br><br></li>
 
             <li><a href="phone-visible.html">Phone number sign-in with visible ReCaptcha</a></li>


### PR DESCRIPTION
MFA was implemented in [auth/mfa-password.ts](https://github.com/firebase/quickstart-js/blob/master/auth/mfa-password.ts) and [auth/mfa-password.html](https://github.com/firebase/quickstart-js/blob/master/auth/mfa-password.html), but there is currently no link to the MFA page.

Adding a link to mfa-password.html in auth/index.html so that users access the mfa page from the main page.

