### PR TITLE
Upgrade Vertex AI in Firebase sample to v11

### DIFF
--- a/vertexai/main.ts
+++ b/vertexai/main.ts
@@ -21,7 +21,7 @@ import {
   initializeAppCheck,
   ReCaptchaEnterpriseProvider,
 } from "firebase/app-check";
-import { getVertexAI, getGenerativeModel } from "firebase/vertexai-preview";
+import { getVertexAI, getGenerativeModel } from "firebase/vertexai";
 
 async function main() {
   const app = initializeApp(firebaseConfig);
@@ -38,7 +38,7 @@ async function main() {
   // Get a Gemini model
   const model = getGenerativeModel(
     vertexAI,
-    { model: "gemini-1.5-flash-preview-0514" }
+    { model: "gemini-1.5-flash" }
   );
   // Call generateContent with a string or Content(s)
   const generateContentResult = await model.generateContent("what is a cat?");

--- a/vertexai/package-lock.json
+++ b/vertexai/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "firebase": "^10.12.0"
+        "firebase": "^11.1.0"
       },
       "devDependencies": {
         "typescript": "^5.1.6",
         "vite": "^4.4.9"
       },
       "engines": {
-        "node": ">=18.0.0 <=20.0.0",
-        "npm": ">=9.0.0 <10.0.0"
+        "node": ">=18.0.0 <=22.10.0",
+        "npm": ">=9.0.0 <=10.9.0"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
@@ -35,23 +35,15 @@
         "node": ">=12"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.3.tgz",
-      "integrity": "sha512-pMADbAgmfM3vDSeINCw0qSTBA9nn6so8min2KaBfu5eda5kfemb/DeawNUKOIxrP3yV4teJgCKA3JFomfnozEg==",
+      "version": "0.10.10",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.10.tgz",
+      "integrity": "sha512-Psdo7c9g2SLAYh6u1XRA+RZ7ab2JfBVuAt/kLzXkhKZL/gS2cQUCMsOW5p0RIlDPRKqpdNSmvujd2TeRWLKOkQ==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/installations": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/installations": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -59,14 +51,14 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.9.tgz",
-      "integrity": "sha512-ZKXaUixA+drbf3meX1bhPCG90UWrpw1KDrCydhe2Uf0VFZmZyVVr0bAcVpqLm29W4td7qp2RpFjVwercZ5mxTg==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.16.tgz",
+      "integrity": "sha512-Q/s+u/TEMSb2EDJFQMGsOzpSosybBl8HuoSEMyGZ99+0Pu7SIR9MPDGUjc8PKiCFQWDJ3QXxgqh1d/rujyAMbA==",
       "dependencies": {
-        "@firebase/analytics": "0.10.3",
-        "@firebase/analytics-types": "0.8.2",
-        "@firebase/component": "0.6.7",
-        "@firebase/util": "1.9.6",
+        "@firebase/analytics": "0.10.10",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.6.11",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -74,89 +66,103 @@
       }
     },
     "node_modules/@firebase/analytics-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.2.tgz",
-      "integrity": "sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw=="
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg=="
     },
     "node_modules/@firebase/app": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.3.tgz",
-      "integrity": "sha512-+pW2wNjijh88aFRjNWhDNlVJI5vB7q1IKYEE79a7ErxwNS/Bo+oh16aAAPvunhT06EF5I8y9gAlNuHNN8u4z8g==",
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.17.tgz",
+      "integrity": "sha512-53sIYyAnYEPIZdaxuyq5OST7j4KBc2pqmktz+tEb1BIUSbXh8Gp4k/o6qzLelLpm4ngrBz7SRN0PZJqNRAyPog==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.4.tgz",
-      "integrity": "sha512-2tjRDaxcM5G7BEpytiDcIl+NovV99q8yEqRMKDbn4J4i/XjjuThuB4S+4PkmTnZiCbdLXQiBhkVxNlUDcfog5Q==",
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.10.tgz",
+      "integrity": "sha512-DWFfxxif/t+Ow4MmRUevDX+A3hVxm1rUf6y5ZP4sIomfnVCO1NNahqtsv9rb1/tKGkTeoVT40weiTS/WjQG1mA==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.11.tgz",
-      "integrity": "sha512-t01zaH3RJpKEey0nGduz3Is+uSz7Sj4U5nwOV6lWb+86s5xtxpIvBJzu/lKxJfYyfZ29eJwpdjEgT1/lm4iQyA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.17.tgz",
+      "integrity": "sha512-a/eadrGsY0MVCBPhrNbKUhoYpms4UKTYLKO7nswwSFVsm3Rw6NslQQCNLfvljcDqP4E7alQDRGJXjkxd/5gJ+Q==",
       "dependencies": {
-        "@firebase/app-check": "0.8.4",
-        "@firebase/app-check-types": "0.5.2",
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/app-check": "0.8.10",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
-      "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ=="
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A=="
     },
     "node_modules/@firebase/app-check-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.2.tgz",
-      "integrity": "sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA=="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng=="
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.2.33",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.33.tgz",
-      "integrity": "sha512-CLXhYJBtLuHXCUvs894gpXEXhZ7Nhytn2icLLIesH+hPLnyBeBf2CSve6Wjig+TOxTdwOQUzdtYpdjmeeYDfpw==",
+      "version": "0.2.47",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.47.tgz",
+      "integrity": "sha512-TdEWGDp6kSwuO1mxiM2Fe39eLWygfyzqTZcoU3aPV0viqqphPCbBBnVjPbFJErZ4+yaS7uCWXEbFEP9m5/COKA==",
       "dependencies": {
-        "@firebase/app": "0.10.3",
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/app": "0.10.17",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
-      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ=="
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw=="
     },
     "node_modules/@firebase/auth": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.3.tgz",
-      "integrity": "sha512-RiU1PjziOxLuyswtYtLK2qSjHIQJQGCk1h986SUFRbMQfzLXbQg8ZgXwxac1UAfDOzgzqPNCXhBuIlSK2UomoQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.8.1.tgz",
+      "integrity": "sha512-LX9N/Cf5Z35r5yqm2+5M3+2bRRe/+RFaa/+u4HDni7TA27C/Xm4XHLKcWcLg1BzjrS4zngSaBEOSODvp6RFOqQ==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
@@ -169,169 +175,202 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.8.tgz",
-      "integrity": "sha512-qUgmv/mcth9wHPTOCKgAOeHe5c+BIOJVcbX2RfcjlXO3xnd8nRafwEkZKBNJUjy4oihYhqFMEMnTHLhwLJwLig==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.16.tgz",
+      "integrity": "sha512-YlYwJMBqAyv0ESy3jDUyshMhZlbUiwAm6B6+uUmigNDHU+uq7j4SFiDJEZlFFIz397yBzKn06SUdqutdQzGnCA==",
       "dependencies": {
-        "@firebase/auth": "1.7.3",
-        "@firebase/auth-types": "0.12.2",
-        "@firebase/component": "0.6.7",
-        "@firebase/util": "1.9.6",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
+        "@firebase/auth": "1.8.1",
+        "@firebase/auth-types": "0.12.3",
+        "@firebase/component": "0.6.11",
+        "@firebase/util": "1.10.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
-      "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ=="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA=="
     },
     "node_modules/@firebase/auth-types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.2.tgz",
-      "integrity": "sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.3.tgz",
+      "integrity": "sha512-Zq9zI0o5hqXDtKg6yDkSnvMCMuLU6qAVS51PANQx+ZZX5xnzyNLEBO3GZgBUPsV5qIMFhjhqmLDxUqCbnAYy2A==",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.7.tgz",
-      "integrity": "sha512-baH1AA5zxfaz4O8w0vDwETByrKTQqB5CDjRls79Sa4eAGAoERw4Tnung7XbMl3jbJ4B/dmmtsMrdki0KikwDYA==",
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.11.tgz",
+      "integrity": "sha512-eQbeCgPukLgsKD0Kw5wQgsMDX5LeoI1MIrziNDjmc6XDq5ZQnuUymANQgAb2wp1tSF9zDSXyxJmIUXaKgN58Ug==",
       "dependencies": {
-        "@firebase/util": "1.9.6",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.1.3.tgz",
+      "integrity": "sha512-FbAQpWNHownJx1VTCQI4ydbWGOZmSWXoFlirQn3ItHqsLJYSywqxSgDafzvyooifFh3J/2WqaM8y9hInnPcsTw==",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.5.tgz",
-      "integrity": "sha512-cAfwBqMQuW6HbhwI3Cb/gDqZg7aR0OmaJ85WUxlnoYW2Tm4eR0hFl5FEijI3/gYPUiUcUPQvTkGV222VkT7KPw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.10.tgz",
+      "integrity": "sha512-sWp2g92u7xT4BojGbTXZ80iaSIaL6GAL0pwvM0CO/hb0nHSnABAqsH7AhnWGsGvXuEvbPr7blZylPaR9J+GSuQ==",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.5.tgz",
-      "integrity": "sha512-NDSMaDjQ+TZEMDMmzJwlTL05kh1+0Y84C+kVMaOmNOzRGRM7VHi29I6YUhCetXH+/b1Wh4ZZRyp1CuWkd8s6hg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.1.tgz",
+      "integrity": "sha512-IsFivOjdE1GrjTeKoBU/ZMenESKDXidFDzZzHBPQ/4P20ptGdrl3oLlWrV/QJqJ9lND4IidE3z4Xr5JyfUW1vg==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/database": "1.0.5",
-        "@firebase/database-types": "1.0.3",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/database": "1.0.10",
+        "@firebase/database-types": "1.0.7",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.3.tgz",
-      "integrity": "sha512-39V/Riv2R3O/aUjYKh0xypj7NTNXNAK1bcgY5Kx+hdQPRS/aPTS8/5c0CGFYKgVuFbYlnlnhrCTYsh2uNhGwzA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.7.tgz",
+      "integrity": "sha512-I7zcLfJXrM0WM+ksFmFdAMdlq/DFmpeMNa+/GNsLyFo5u/lX5zzkPzGe3srVWqaBQBY5KprylDGxOsP6ETfL0A==",
       "dependencies": {
-        "@firebase/app-types": "0.9.2",
-        "@firebase/util": "1.9.6"
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.10.2"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.6.2.tgz",
-      "integrity": "sha512-sxHtvmfH/1689aPQRxOXBWDumaPqg5AjQVkfwpt+Z3rnaa0aLJlrt2PZs9Xh04qbmWiwtkDgztFmoR/aQdMQJQ==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.5.tgz",
+      "integrity": "sha512-OO3rHvjC07jL2ITN255xH/UzCVSvh6xG8oTzQdFScQvFbcm1fjCL1hgAdpDZcx3vVcKMV+6ktr8wbllkB8r+FQ==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
-        "@firebase/webchannel-wrapper": "1.0.0",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
+        "@firebase/webchannel-wrapper": "1.0.3",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
+        "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.31.tgz",
-      "integrity": "sha512-YbR9GGLfYY9A5Qh2SyyNz7EsNeC5SRjzgRxtMtqz2s2es+p+5sDfFUUNKqpgVaIcnoPGOtvCLhNNWG/TBmlQjw==",
+      "version": "0.3.40",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.40.tgz",
+      "integrity": "sha512-18HopMN811KYBc9Ptpr1Rewwio0XF09FF3jc5wtV6rGyAs815SlFFw5vW7ZeLd43zv9tlEc2FzM0H+5Vr9ZRxw==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/firestore": "4.6.2",
-        "@firebase/firestore-types": "3.0.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/firestore": "4.7.5",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/firestore-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.2.tgz",
-      "integrity": "sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.5.tgz",
-      "integrity": "sha512-qrHJ+l62mZiU5UZiVi84t/iLXZlhRuSvBQsa2qvNLgPsEWR7wdpWhRmVdB7AU8ndkSHJjGlMICqrVnz47sgU7Q==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.0.tgz",
+      "integrity": "sha512-plTtzY/nT0jOgHzT0vB9qch4FpHFOhCnR8HhYBqqdArG6GOQMIruKZbiTyLybO8bcaaNgQ6kSm9yohGUwxHcIw==",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.7",
-        "@firebase/messaging-interop-types": "0.2.2",
-        "@firebase/util": "1.9.6",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.6.11",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.10.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.11.tgz",
-      "integrity": "sha512-Qn+ts/M6Lj2/6i1cp5V5TRR+Hi9kyXyHbo+w9GguINJ87zxrCe6ulx3TI5AGQkoQa8YFHUhT3DMGmLFiJjWTSQ==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.17.tgz",
+      "integrity": "sha512-oj2XV8YsJYutyPCRYUfbN6swmfrL6zar0/qtqZsKT7P7btOiYRl+lD6fxtQaT+pKE5YgOBGZW//kLPZfY0jWhw==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/functions": "0.11.5",
-        "@firebase/functions-types": "0.6.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/functions": "0.12.0",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/functions-types": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.2.tgz",
-      "integrity": "sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg=="
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.7.tgz",
-      "integrity": "sha512-i6iGoXRu5mX4rTsiMSSKrgh9pSEzD4hwBEzRh5kEhOTr8xN/wvQcCPZDSMVYKwM2XyCPBLVq0JzjyerwL0Rihg==",
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.11.tgz",
+      "integrity": "sha512-w8fY8mw6fxJzsZM2ufmTtomopXl1+bn/syYon+Gpn+0p0nO1cIUEVEFrFazTLaaL9q1CaVhc3HmseRTsI3igAA==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/util": "1.10.2",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -340,14 +379,14 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.7.tgz",
-      "integrity": "sha512-RPcbD+3nqHbnhVjIOpWK2H5qzZ8pAAAScceiWph0VNTqpKyPQ5tDcp4V5fS0ELpfgsHYvroMLDKfeHxpfvm8cw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.11.tgz",
+      "integrity": "sha512-SHRgw5LTa6v8LubmJZxcOCwEd1MfWQPUtKdiuCx2VMWnapX54skZd1PkQg0K4l3k+4ujbI2cn7FE6Li9hbChBw==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/installations": "0.6.7",
-        "@firebase/installations-types": "0.5.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/installations": "0.6.11",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -355,30 +394,33 @@
       }
     },
     "node_modules/@firebase/installations-types": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.2.tgz",
-      "integrity": "sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
       "peerDependencies": {
         "@firebase/app-types": "0.x"
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
-      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
+      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
       "dependencies": {
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.9.tgz",
-      "integrity": "sha512-IH+JJmzbFGZXV3+TDyKdqqKPVfKRqBBg2BfYYOy7cm7J+SwV+uJMe8EnDKYeQLEQhtpwciPfJ3qQXJs2lbxDTw==",
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.15.tgz",
+      "integrity": "sha512-Bz+qvWNEwEWAbYtG4An8hgcNco6NWNoNLuLbGVwPL2fAoCF1zz+dcaBp+iTR2+K199JyRyDT9yDPAXhNHNDaKQ==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/installations": "0.6.7",
-        "@firebase/messaging-interop-types": "0.2.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/installations": "0.6.11",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.10.2",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -387,13 +429,13 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.9.tgz",
-      "integrity": "sha512-5jN6wyhwPgBH02zOtmmoOeyfsmoD7ty48D1m0vVPsFg55RqN2Z3Q9gkZ5GmPklFPjTPLcxB1ObcHOZvThTkm7g==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.15.tgz",
+      "integrity": "sha512-mEKKASRvRWq1aBNHgioGsOYR2c5nBZpO7k90K794zjKe0WkGNf0k7PLs5SlCf8FKnzumEkhTAp/SjYxovuxa8A==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/messaging": "0.12.9",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/messaging": "0.12.15",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -401,19 +443,19 @@
       }
     },
     "node_modules/@firebase/messaging-interop-types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.2.tgz",
-      "integrity": "sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q=="
     },
     "node_modules/@firebase/performance": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.7.tgz",
-      "integrity": "sha512-d+Q4ltjdJZqjzcdms5i0UC9KLYX7vKGcygZ+7zHA/Xk+bAbMD2CPU0nWTnlNFWifZWIcXZ/2mAMvaGMW3lypUA==",
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.11.tgz",
+      "integrity": "sha512-FlkJFeqLlIeh5T4Am3uE38HVzggliDIEFy/fErEc1faINOUFCb6vQBEoNZGaXvRnTR8lh3X/hP7tv37C7BsK9g==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/installations": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/installations": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -421,15 +463,15 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.7.tgz",
-      "integrity": "sha512-cb8ge/5iTstxfIGW+iiY+7l3FtN8gobNh9JSQNZgLC9xmcfBYWEs8IeEWMI6S8T+At0oHc3lv+b2kpRMUWr8zQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.11.tgz",
+      "integrity": "sha512-DqeNBy51W2xzlklyC7Ht9JQ94HhTA08PCcM4MDeyG/ol3fqum/+YgtHWQ2IQuduqH9afETthZqLwCZiSgY7hiA==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/performance": "0.6.7",
-        "@firebase/performance-types": "0.2.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/performance": "0.6.11",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -437,19 +479,19 @@
       }
     },
     "node_modules/@firebase/performance-types": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.2.tgz",
-      "integrity": "sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ=="
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.7.tgz",
-      "integrity": "sha512-5oPNrPFLsbsjpq0lUEIXoDF2eJK7vAbyXe/DEuZQxnwJlfR7aQbtUlEkRgQWcicXpyDmAmDLo7q7lDbCYa6CpA==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.11.tgz",
+      "integrity": "sha512-9z0rgKuws2nj+7cdiqF+NY1QR4na6KnuOvP+jQvgilDOhGtKOcCMq5XHiu66i73A9kFhyU6QQ2pHXxcmaq1pBw==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/installations": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/installations": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -457,15 +499,15 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.7.tgz",
-      "integrity": "sha512-Fq0oneQ4SluLnfr5/HfzRS1TZf1ANj1rWbCCW3+oC98An3nE+sCdp+FSuHsEVNwgMg4Tkwx9Oom2lkKeU+Vn+w==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.11.tgz",
+      "integrity": "sha512-zfIjpwPrGuIOZDmduukN086qjhZ1LnbJi/iYzgua+2qeTlO0XdlE1v66gJPwygGB3TOhT0yb9EiUZ3nBNttMqg==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/remote-config": "0.4.7",
-        "@firebase/remote-config-types": "0.3.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/remote-config": "0.4.11",
+        "@firebase/remote-config-types": "0.3.3",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -473,65 +515,73 @@
       }
     },
     "node_modules/@firebase/remote-config-types": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
-      "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA=="
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.3.tgz",
+      "integrity": "sha512-YlRI9CHxrk3lpQuFup9N1eohpwdWayKZUNZ/YeQ0PZoncJ66P32UsKUKqVXOaieTjJIOh7yH8JEzRdht5s+d6g=="
     },
     "node_modules/@firebase/storage": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.12.5.tgz",
-      "integrity": "sha512-nGWBOGFNr10j0LA4NJ3/Yh3us/lb0Q1xSIKZ38N6FcS+vY54nqJ7k3zE3PENregHC8+8txRow++A568G3v8hOA==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.4.tgz",
+      "integrity": "sha512-b1KaTTRiMupFurIhpGIbReaWev0k5O3ouTHkAPcEssT+FvU3q/1JwzvkX4+ZdB60Fc43Mbp8qQ1gWfT0Z2FP9Q==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/util": "1.9.6",
-        "tslib": "^2.1.0",
-        "undici": "5.28.4"
+        "@firebase/component": "0.6.11",
+        "@firebase/util": "1.10.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.8.tgz",
-      "integrity": "sha512-qDfY9kMb6Ch2hZb40sBjDQ8YPxbjGOxuT+gU1Z0iIVSSpSX0f4YpGJCypUXiA0T11n6InCXB+T/Dknh2yxVTkg==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.14.tgz",
+      "integrity": "sha512-Ok5FmXJiapaNAOQ8W8qppnfwgP8540jw2B8M0c4TFZqF4BD+CoKBxW0dRtOuLNGadLhzqqkDZZZtkexxrveQqA==",
       "dependencies": {
-        "@firebase/component": "0.6.7",
-        "@firebase/storage": "0.12.5",
-        "@firebase/storage-types": "0.8.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/component": "0.6.11",
+        "@firebase/storage": "0.13.4",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/storage-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.2.tgz",
-      "integrity": "sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.6.tgz",
-      "integrity": "sha512-IBr1MZbp4d5MjBCXL3TW1dK/PDXX4yOGbiwRNh1oAbE/+ci5Uuvy9KIrsFYY80as1I0iOaD5oOMA9Q8j4TJWcw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.2.tgz",
+      "integrity": "sha512-qnSHIoE9FK+HYnNhTI8q14evyqbc/vHRivfB4TgCIUOl4tosmKSQlp7ltymOlMP4xVIJTg5wrkfcZ60X4nUf7Q==",
       "dependencies": {
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@firebase/vertexai-preview": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@firebase/vertexai-preview/-/vertexai-preview-0.0.1.tgz",
-      "integrity": "sha512-N8m9Xr0YZKy0t9SpQDuHrL2ppEAT/iqf88Y/O00QNA/Td/BMCL8sJ0c+Savh1TVrqh0rNp9n6HkZ39e/O5mwhA==",
+    "node_modules/@firebase/vertexai": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/vertexai/-/vertexai-1.0.2.tgz",
+      "integrity": "sha512-4dC9m2nD0tkfKJT5v+i27tELrmUePjFXW3CDAxhVHUEv647B2R7kqpGQnyPkNEeaXkCr76THe7GGg35EWn4lDw==",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.2",
-        "@firebase/component": "0.6.7",
-        "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.6",
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.6.11",
+        "@firebase/logger": "0.4.4",
+        "@firebase/util": "1.10.2",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -543,14 +593,14 @@
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.0.tgz",
-      "integrity": "sha512-zuWxyfXNbsKbm96HhXzainONPFqRcoZblQ++e9cAIGUuHfl2cFSBzW01jtesqWG/lqaUyX3H8O1y9oWboGNQBA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz",
+      "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ=="
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.14",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.14.tgz",
-      "integrity": "sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==",
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -730,9 +780,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "engines": {
         "node": ">=6"
       }
@@ -749,37 +799,38 @@
       }
     },
     "node_modules/firebase": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.12.0.tgz",
-      "integrity": "sha512-31UZyAK0+VZmF9jR/+6g31uyqWjBKsG+TV3ndRJEkw6+Skctb5ZX0+Ezq/pbC68iIRJ5TujOjyl632vTOqyS1w==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.1.0.tgz",
+      "integrity": "sha512-3OoNW3vBXmBLYJvcwbPCwfluptbDVp2zZYjrfHPVFAXfPgmyy/LWjidt+Sw2WNvRelsG0v++WN2Wor6J3OwDRg==",
       "dependencies": {
-        "@firebase/analytics": "0.10.3",
-        "@firebase/analytics-compat": "0.2.9",
-        "@firebase/app": "0.10.3",
-        "@firebase/app-check": "0.8.4",
-        "@firebase/app-check-compat": "0.3.11",
-        "@firebase/app-compat": "0.2.33",
-        "@firebase/app-types": "0.9.2",
-        "@firebase/auth": "1.7.3",
-        "@firebase/auth-compat": "0.5.8",
-        "@firebase/database": "1.0.5",
-        "@firebase/database-compat": "1.0.5",
-        "@firebase/firestore": "4.6.2",
-        "@firebase/firestore-compat": "0.3.31",
-        "@firebase/functions": "0.11.5",
-        "@firebase/functions-compat": "0.3.11",
-        "@firebase/installations": "0.6.7",
-        "@firebase/installations-compat": "0.2.7",
-        "@firebase/messaging": "0.12.9",
-        "@firebase/messaging-compat": "0.2.9",
-        "@firebase/performance": "0.6.7",
-        "@firebase/performance-compat": "0.2.7",
-        "@firebase/remote-config": "0.4.7",
-        "@firebase/remote-config-compat": "0.2.7",
-        "@firebase/storage": "0.12.5",
-        "@firebase/storage-compat": "0.3.8",
-        "@firebase/util": "1.9.6",
-        "@firebase/vertexai-preview": "0.0.1"
+        "@firebase/analytics": "0.10.10",
+        "@firebase/analytics-compat": "0.2.16",
+        "@firebase/app": "0.10.17",
+        "@firebase/app-check": "0.8.10",
+        "@firebase/app-check-compat": "0.3.17",
+        "@firebase/app-compat": "0.2.47",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/auth": "1.8.1",
+        "@firebase/auth-compat": "0.5.16",
+        "@firebase/data-connect": "0.1.3",
+        "@firebase/database": "1.0.10",
+        "@firebase/database-compat": "2.0.1",
+        "@firebase/firestore": "4.7.5",
+        "@firebase/firestore-compat": "0.3.40",
+        "@firebase/functions": "0.12.0",
+        "@firebase/functions-compat": "0.3.17",
+        "@firebase/installations": "0.6.11",
+        "@firebase/installations-compat": "0.2.11",
+        "@firebase/messaging": "0.12.15",
+        "@firebase/messaging-compat": "0.2.15",
+        "@firebase/performance": "0.6.11",
+        "@firebase/performance-compat": "0.2.11",
+        "@firebase/remote-config": "0.4.11",
+        "@firebase/remote-config-compat": "0.2.11",
+        "@firebase/storage": "0.13.4",
+        "@firebase/storage-compat": "0.3.14",
+        "@firebase/util": "1.10.2",
+        "@firebase/vertexai": "1.0.2"
       }
     },
     "node_modules/fsevents": {
@@ -880,9 +931,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
-      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -977,9 +1028,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/typescript": {
       "version": "5.4.4",
@@ -991,17 +1042,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/vertexai/package.json
+++ b/vertexai/package.json
@@ -12,8 +12,8 @@
     "url": "https://github.com/firebase/quickstart-js/issues"
   },
   "engines": {
-    "npm": ">=9.0.0 <10.0.0",
-    "node": ">=18.0.0 <=20.0.0"
+    "npm": ">=9.0.0 <=10.9.0",
+    "node": ">=18.0.0 <=22.10.0"
   },
   "homepage": "https://github.com/firebase/quickstart-js#readme",
   "devDependencies": {
@@ -26,6 +26,6 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "firebase": "^10.12.0"
+    "firebase": "^11.1.0"
   }
 }


### PR DESCRIPTION
- Upgrade Firebase from v10 to v11
- Use `firebase/vertexai` instead of `firebase/vertexai-preview`
- Upgrade Node and NPM version requirements
- Use non-preview model (?)