### PR TITLE
Do not run ESLint in `dataconnect-sdk`

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
 set -e
 # Run linter
-find . -type f -name "*.js" -not -path "*node_modules*" \
+find . -type f -name "*.js" -not -path "*node_modules*" -not -path "*dataconnect-sdk/*" \
   | xargs eslint


### PR DESCRIPTION
Tests began failing after the introduction of `dataconnect/app/src/lib/dataconnect-sdk` in https://github.com/firebase/quickstart-js/pull/835, since that code does not comply with ESLint rules. I believe this is the generated dataconnect SDK, so instead of fixing the linting issues I think we should just not run ESLint against this generated code. Very open to other suggestions for fixing this- I'm looking to unblock CI failing on all branches.