### PR TITLE
Add gemini-2.5-flash to Firebase AI sample app

### DIFF
--- a/ai/ai-react-app/src/services/firebaseAIService.ts
+++ b/ai/ai-react-app/src/services/firebaseAIService.ts
@@ -19,6 +19,7 @@ export const AVAILABLE_GENERATIVE_MODELS = [
   "gemini-2.0-flash",
   "gemini-2.0-flash-lite",
   "gemini-2.0-flash-exp",
+  "gemini-2.5-flash"
 ];
 export const AVAILABLE_IMAGEN_MODELS = ["imagen-3.0-generate-002"];
 


### PR DESCRIPTION
Adds `gemini-2.5-flash` to the Firebase AI Sample React App.