### PR TITLE
chore(config) Update available imagen models in AI example

### DIFF
--- a/ai/ai-react-app/src/services/firebaseAIService.ts
+++ b/ai/ai-react-app/src/services/firebaseAIService.ts
@@ -23,7 +23,11 @@ export const AVAILABLE_GENERATIVE_MODELS = [
   "gemini-2.0-flash-exp",
   "gemini-2.5-flash"
 ];
-export const AVAILABLE_IMAGEN_MODELS = ["imagen-4.0-generate-001", "imagen-4.0-fast-generate-001", "imagen-4.0-ultra-generate-001"];
+export const AVAILABLE_IMAGEN_MODELS = [
+  "imagen-4.0-generate-001",
+  "imagen-4.0-fast-generate-001",
+  "imagen-4.0-ultra-generate-001"
+];
 export const LIVE_MODELS = new Map<BackendType, string>([
   [BackendType.GOOGLE_AI, 'gemini-live-2.5-flash-preview'],
   [BackendType.VERTEX_AI, 'gemini-2.0-flash-exp']


### PR DESCRIPTION
The current model configured in `AVAILABLE_IMAGEN_MODELS` is no longer aviailble. Update the list to include our currently supported models.